### PR TITLE
feat: delete extra locales

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,5 +1,6 @@
 appId: dnschanger.github.io
 productName: DNS Changer (OpenSource)
+afterPack: "removeLocales.js"
 artifactName: "${productName}-${os}-${arch}-${version}.${ext}"
 files:
   - "**/*"

--- a/removeLocales.js
+++ b/removeLocales.js
@@ -1,0 +1,18 @@
+//https://www.electron.build/configuration/configuration#afterpack
+exports.default = async function(context) {
+    //console.log(context)
+    var fs = require('fs');
+    var localeDir = context.appOutDir+'/locales/';
+
+    fs.readdir(localeDir, function(err, files){
+        //files is array of filenames (basename form)
+        if(!(files && files.length)) return;
+        for (var i = 0, len = files.length; i < len; i++) {
+            var matchEn = files[i].match(/en-US\.pak/);
+            var matchFa = files[i].match(/fa\.pak/);
+            if(matchEn === null && matchFa === null){
+                fs.unlinkSync(localeDir+files[i]);
+            }
+        }
+    });
+}


### PR DESCRIPTION
Deleting extra locales form ```win-unpacked\locales``` via ```afterPack``` hook reduced 5~6 MB of .exe size and ~25 MB after installation(unpackaged). Please first test to see if it conflict with translation.