### PR TITLE
Support Ethernet for mac mini and mac studio

### DIFF
--- a/src/main/platforms/mac/mac.platform.ts
+++ b/src/main/platforms/mac/mac.platform.ts
@@ -37,6 +37,8 @@ export class MacPlatform extends Platform {
       const dnsServers = nameServers.join(" ");
 
       await execPromise(`networksetup -setdnsservers Wi-Fi ${dnsServers}`);
+      await execPromise(`networksetup -setdnsservers Ethernet ${dnsServers}`);
+
     } catch (e) {
       throw e;
     }


### PR DESCRIPTION
Add dns to Ethernet for  mac mini and mac studio when set new dns