### PR TITLE
fix(linux): NetworkManager/systemd-resolved DNS + packaging

### DIFF
--- a/build/postinst.sh
+++ b/build/postinst.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+# Install prefix used by electron-builder for deb (productName → DNSChanger)
+INSTALL_DIR="/opt/DNSChanger"
+BIN_NAME="dnschanger"
+
+# Chromium SUID sandbox (required for Electron without --no-sandbox)
+SANDBOX="${INSTALL_DIR}/chrome-sandbox"
+if [ -f "$SANDBOX" ]; then
+	chown root:root "$SANDBOX"
+	chmod 4755 "$SANDBOX"
+fi
+
+# Ensure binary is on PATH (some packages only install under /opt)
+if [ -x "${INSTALL_DIR}/${BIN_NAME}" ]; then
+	ln -sf "${INSTALL_DIR}/${BIN_NAME}" "/usr/bin/${BIN_NAME}"
+fi
+
+# Refresh desktop/mime databases when tools are available
+if command -v update-desktop-database >/dev/null 2>&1; then
+	update-desktop-database -q /usr/share/applications 2>/dev/null || true
+fi
+
+if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+	gtk-update-icon-cache -q -t -f /usr/share/icons/hicolor 2>/dev/null || true
+fi

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,5 +1,5 @@
 appId: dnschanger.github.io
-productName: DNS Changer
+productName: DNSChanger
 afterPack: 'removeLocales.js'
 artifactName: '${productName}-${os}-${arch}-${version}.${ext}'
 files:
@@ -17,7 +17,9 @@ files:
   - '!**/.eslint*'
   - '!**/jest*'
   - '!**/*.test.*'
+  - '!**/*.spec.*'
   - '!**/__tests__'
+  - '!**/__test__'
 asar: true
 compression: maximum
 directories:
@@ -32,15 +34,45 @@ win:
     - msi
     - nsis
 linux:
-  icon: 'public/icons/icon.icns'
+  icon: 'public/icons/icon.png'
   maintainer: 'dnschanger.github.io'
+  vendor: 'DnsChanger'
+  synopsis: 'DNS Changer for Linux'
+  description: 'Change system DNS settings easily on Linux (NetworkManager / systemd-resolved)'
+  executableName: dnschanger
+  desktop:
+    entry:
+      Name: DNS Changer
+      Comment: Change system DNS settings easily
+      Categories: Utility;Network;
+      StartupWMClass: dnschanger
+      Terminal: false
+      Type: Application
   target:
-    - rpm
     - AppImage
     - deb
-  category: Utilities
+    - rpm
+  category: Utility
   publish:
     - github
+deb:
+  packageName: dnschanger
+  depends:
+    - libgtk-3-0
+    - libnotify4
+    - libnss3
+    - libxss1
+    - libxtst6
+    - xdg-utils
+    - libatspi2.0-0
+    - libuuid1
+    - libsecret-1-0
+  recommends:
+    - libappindicator3-1
+    - network-manager
+  afterInstall: 'build/postinst.sh'
+rpm:
+  packageName: dnschanger
 mac:
   icon: 'public/icons/icon.png'
   target:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "dnschanger",
   "productName": "dnschanger",
+  "desktopName": "dnschanger.desktop",
   "version": "2.3.7",
   "debug": {
     "env": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -27,6 +27,15 @@ process.env.PUBLIC = process.env.VITE_DEV_SERVER_URL
 
 if (release().startsWith('6.1')) app.disableHardwareAcceleration()
 
+// Native Wayland when available (KDE/GNOME); falls back to XWayland automatically
+if (process.platform === 'linux') {
+	app.commandLine.appendSwitch('ozone-platform-hint', 'auto')
+	app.commandLine.appendSwitch(
+		'enable-features',
+		'UseOzonePlatform,WaylandWindowDecorations',
+	)
+}
+
 if (process.platform === 'win32') app.setAppUserModelId(app.getName())
 
 if (!app.requestSingleInstanceLock()) {

--- a/src/main/platforms/linux/__test__/linux-dns.util.spec.ts
+++ b/src/main/platforms/linux/__test__/linux-dns.util.spec.ts
@@ -1,0 +1,41 @@
+import { parseIpv4DnsList, pickPreferredConnection, shellQuote } from '../linux-dns.util'
+
+describe('linux-dns.util', () => {
+	describe('shellQuote', () => {
+		it('wraps plain values in single quotes', () => {
+			expect(shellQuote('eth0')).toBe("'eth0'")
+		})
+
+		it('escapes embedded single quotes', () => {
+			expect(shellQuote("Wired connection's 1")).toBe("'Wired connection'\\''s 1'")
+		})
+	})
+
+	describe('parseIpv4DnsList', () => {
+		it('extracts unique IPv4 addresses', () => {
+			expect(
+				parseIpv4DnsList(
+					'nameserver 1.1.1.1\nnameserver 8.8.8.8\nnameserver 1.1.1.1'
+				)
+			).toEqual(['1.1.1.1', '8.8.8.8'])
+		})
+
+		it('ignores invalid octets', () => {
+			expect(parseIpv4DnsList('999.1.1.1 1.2.3.4')).toEqual(['1.2.3.4'])
+		})
+	})
+
+	describe('pickPreferredConnection', () => {
+		it('prefers ethernet/wifi over vpn', () => {
+			const picked = pickPreferredConnection([
+				{ name: 'vpn', device: 'tun0', type: 'vpn' },
+				{ name: 'Home', device: 'wlan0', type: '802-11-wireless' },
+			])
+			expect(picked?.device).toBe('wlan0')
+		})
+
+		it('returns null for empty list', () => {
+			expect(pickPreferredConnection([])).toBeNull()
+		})
+	})
+})

--- a/src/main/platforms/linux/__test__/linux.platform.spec.ts
+++ b/src/main/platforms/linux/__test__/linux.platform.spec.ts
@@ -1,0 +1,221 @@
+jest.mock('../../../store/store', () => ({
+	store: {
+		get: jest.fn(() => ({ network_interface: 'Auto' })),
+	},
+}))
+
+jest.mock('../linux-dns.util', () => {
+	const actual = jest.requireActual('../linux-dns.util')
+	return {
+		...actual,
+		detectLinuxDnsBackend: jest.fn(),
+		listNmConnections: jest.fn(),
+		listNmDevices: jest.fn(),
+		listIpDevices: jest.fn(),
+		getDefaultRouteInterface: jest.fn(),
+		commandExists: jest.fn(),
+		runUserCmd: jest.fn(),
+	}
+})
+
+import { store } from '../../../store/store'
+import { LinuxPlatform } from '../linux.platform'
+import * as linuxDnsUtil from '../linux-dns.util'
+
+describe('LinuxPlatform', () => {
+	let platform: LinuxPlatform
+
+	beforeEach(() => {
+		jest.clearAllMocks()
+		platform = new LinuxPlatform()
+		;(store.get as jest.Mock).mockReturnValue({ network_interface: 'Auto' })
+	})
+
+	describe('setDns (NetworkManager)', () => {
+		it('sets ipv4.dns and ignores auto dns on the active connection', async () => {
+			;(linuxDnsUtil.detectLinuxDnsBackend as jest.Mock).mockResolvedValue(
+				'networkmanager'
+			)
+			;(linuxDnsUtil.listNmConnections as jest.Mock).mockResolvedValue([
+				{ name: 'Wired connection 1', device: 'eth0', type: '802-3-ethernet' },
+			])
+
+			const execSpy = jest
+				.spyOn(LinuxPlatform.prototype as any, 'execCmd')
+				.mockResolvedValue('')
+
+			await platform.setDns(['1.1.1.1', '8.8.8.8'])
+
+			expect(execSpy).toHaveBeenCalledTimes(1)
+			const cmd = execSpy.mock.calls[0][0] as string
+			expect(cmd).toContain('nmcli con mod')
+			expect(cmd).toContain('ipv4.dns')
+			expect(cmd).toContain('1.1.1.1 8.8.8.8')
+			expect(cmd).toContain('ipv4.ignore-auto-dns yes')
+			expect(cmd).toContain('nmcli con up')
+		})
+	})
+
+	describe('clearDns (NetworkManager)', () => {
+		it('restores automatic DNS (DHCP) instead of hardcoding public resolvers', async () => {
+			;(linuxDnsUtil.detectLinuxDnsBackend as jest.Mock).mockResolvedValue(
+				'networkmanager'
+			)
+			;(linuxDnsUtil.listNmConnections as jest.Mock).mockResolvedValue([
+				{ name: 'WiFi', device: 'wlan0', type: '802-11-wireless' },
+			])
+
+			const execSpy = jest
+				.spyOn(LinuxPlatform.prototype as any, 'execCmd')
+				.mockResolvedValue('')
+
+			await platform.clearDns()
+
+			const cmd = execSpy.mock.calls[0][0] as string
+			expect(cmd).toContain('ipv4.ignore-auto-dns no')
+			expect(cmd).not.toContain('8.8.8.8')
+			expect(cmd).not.toContain('1.1.1.1')
+		})
+	})
+
+	describe('setDns (systemd-resolved)', () => {
+		it('uses resolvectl on the default interface', async () => {
+			;(linuxDnsUtil.detectLinuxDnsBackend as jest.Mock).mockResolvedValue(
+				'systemd-resolved'
+			)
+			;(linuxDnsUtil.getDefaultRouteInterface as jest.Mock).mockResolvedValue(
+				'enp0s3'
+			)
+
+			const execSpy = jest
+				.spyOn(LinuxPlatform.prototype as any, 'execCmd')
+				.mockResolvedValue('')
+
+			await platform.setDns(['9.9.9.9'])
+
+			const cmd = execSpy.mock.calls[0][0] as string
+			expect(cmd).toContain('resolvectl dns')
+			expect(cmd).toContain('enp0s3')
+			expect(cmd).toContain('9.9.9.9')
+			expect(cmd).toContain('resolvectl domain')
+		})
+	})
+
+	describe('clearDns (systemd-resolved)', () => {
+		it('reverts the interface DNS configuration', async () => {
+			;(linuxDnsUtil.detectLinuxDnsBackend as jest.Mock).mockResolvedValue(
+				'systemd-resolved'
+			)
+			;(linuxDnsUtil.getDefaultRouteInterface as jest.Mock).mockResolvedValue(
+				'enp0s3'
+			)
+
+			const execSpy = jest
+				.spyOn(LinuxPlatform.prototype as any, 'execCmd')
+				.mockResolvedValue('')
+
+			await platform.clearDns()
+
+			expect(execSpy.mock.calls[0][0]).toContain('resolvectl revert')
+		})
+	})
+
+	describe('setDns (resolvconf fallback)', () => {
+		it('backs up resolv.conf and writes nameservers without restarting networkd', async () => {
+			;(linuxDnsUtil.detectLinuxDnsBackend as jest.Mock).mockResolvedValue(
+				'resolvconf'
+			)
+
+			const execSpy = jest
+				.spyOn(LinuxPlatform.prototype as any, 'execCmd')
+				.mockResolvedValue('')
+
+			await platform.setDns(['1.1.1.1', '1.0.0.1'])
+
+			const cmd = execSpy.mock.calls[0][0] as string
+			expect(cmd).toContain('resolv.conf.dnschanger.bak')
+			expect(cmd).toContain('base64 -d')
+			expect(cmd).not.toContain('systemd-networkd')
+		})
+	})
+
+	describe('getActiveDns', () => {
+		it('reads DNS from NetworkManager connection', async () => {
+			;(linuxDnsUtil.detectLinuxDnsBackend as jest.Mock).mockResolvedValue(
+				'networkmanager'
+			)
+			;(linuxDnsUtil.listNmConnections as jest.Mock).mockResolvedValue([
+				{ name: 'Wired', device: 'eth0', type: 'ethernet' },
+			])
+			;(linuxDnsUtil.runUserCmd as jest.Mock).mockResolvedValue(
+				'IP4.DNS:1.1.1.1\nIP4.DNS:8.8.8.8\n'
+			)
+
+			await expect(platform.getActiveDns()).resolves.toEqual(['1.1.1.1', '8.8.8.8'])
+		})
+	})
+
+	describe('getInterfacesList', () => {
+		it('returns connected NetworkManager devices', async () => {
+			;(linuxDnsUtil.listNmDevices as jest.Mock).mockResolvedValue([
+				{
+					device: 'wlan0',
+					type: 'wifi',
+					state: 'connected',
+					connection: 'Home',
+				},
+				{
+					device: 'eth0',
+					type: 'ethernet',
+					state: 'disconnected',
+					connection: '',
+				},
+			])
+
+			const list = await platform.getInterfacesList()
+			expect(list).toHaveLength(1)
+			expect(list[0].name).toBe('wlan0')
+			expect(list[0].type).toBe('Wireless')
+		})
+	})
+
+	describe('flushDns', () => {
+		it('prefers resolvectl flush-caches', async () => {
+			;(linuxDnsUtil.commandExists as jest.Mock).mockImplementation(
+				async (bin: string) => bin === 'resolvectl'
+			)
+
+			const execSpy = jest
+				.spyOn(LinuxPlatform.prototype as any, 'execCmd')
+				.mockResolvedValue('')
+
+			await platform.flushDns()
+
+			expect(execSpy).toHaveBeenCalledWith('resolvectl flush-caches')
+		})
+	})
+
+	describe('network interface setting', () => {
+		it('uses the configured device when not Auto', async () => {
+			;(store.get as jest.Mock).mockReturnValue({
+				network_interface: 'wlan0',
+			})
+			;(linuxDnsUtil.detectLinuxDnsBackend as jest.Mock).mockResolvedValue(
+				'networkmanager'
+			)
+			;(linuxDnsUtil.listNmConnections as jest.Mock).mockResolvedValue([
+				{ name: 'Ethernet', device: 'eth0', type: 'ethernet' },
+				{ name: 'WiFi', device: 'wlan0', type: 'wifi' },
+			])
+
+			const execSpy = jest
+				.spyOn(LinuxPlatform.prototype as any, 'execCmd')
+				.mockResolvedValue('')
+
+			await platform.setDns(['8.8.8.8'])
+
+			const cmd = execSpy.mock.calls[0][0] as string
+			expect(cmd).toContain("'WiFi'")
+		})
+	})
+})

--- a/src/main/platforms/linux/linux-dns.util.ts
+++ b/src/main/platforms/linux/linux-dns.util.ts
@@ -1,0 +1,183 @@
+import { exec } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execAsync = promisify(exec)
+
+export type LinuxDnsBackend = 'networkmanager' | 'systemd-resolved' | 'resolvconf'
+
+export const RESOLV_BACKUP_PATH = '/etc/resolv.conf.dnschanger.bak'
+
+/** POSIX-safe single-quote for shell arguments. */
+export function shellQuote(value: string): string {
+	return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+export async function runUserCmd(cmd: string): Promise<string> {
+	const { stdout } = await execAsync(cmd, { timeout: 15_000 })
+	return (stdout ?? '').toString()
+}
+
+export async function commandExists(bin: string): Promise<boolean> {
+	try {
+		await runUserCmd(`command -v ${shellQuote(bin)}`)
+		return true
+	} catch {
+		return false
+	}
+}
+
+export async function isServiceActive(service: string): Promise<boolean> {
+	try {
+		const out = await runUserCmd(
+			`systemctl is-active ${shellQuote(service)} 2>/dev/null || true`
+		)
+		return out.trim() === 'active'
+	} catch {
+		return false
+	}
+}
+
+export async function isResolvConfManagedByResolved(): Promise<boolean> {
+	try {
+		const target = (
+			await runUserCmd('readlink -f /etc/resolv.conf 2>/dev/null || true')
+		).trim()
+		if (!target) return false
+		return (
+			target.includes('systemd') ||
+			target.includes('stub-resolv.conf') ||
+			target.includes('resolv.conf.d')
+		)
+	} catch {
+		return false
+	}
+}
+
+export function parseIpv4DnsList(text: string): string[] {
+	const matches = text.match(/\b(?:\d{1,3}\.){3}\d{1,3}\b/g) || []
+	return [...new Set(matches)].filter((ip) => {
+		const parts = ip.split('.').map(Number)
+		return parts.length === 4 && parts.every((p) => p >= 0 && p <= 255)
+	})
+}
+
+export interface LinuxConnection {
+	name: string
+	device: string
+	type: string
+}
+
+/**
+ * Prefer ethernet/wifi connections; skip loopback and typically ignore pure VPN
+ * unless nothing else is connected.
+ */
+export function pickPreferredConnection(
+	connections: LinuxConnection[]
+): LinuxConnection | null {
+	if (!connections.length) return null
+
+	const isPrimary = (c: LinuxConnection) =>
+		/ethernet|wifi|wireless|802-11|802-3/i.test(c.type) ||
+		(!/vpn|bridge|tun|tap|loopback|docker|veth/i.test(c.type) &&
+			!/^(lo|docker|veth|br-)/i.test(c.device))
+
+	return connections.find(isPrimary) || connections[0]
+}
+
+export async function listNmConnections(): Promise<LinuxConnection[]> {
+	const stdout = await runUserCmd(
+		'nmcli -t -f NAME,DEVICE,TYPE con show --active 2>/dev/null || true'
+	)
+
+	return stdout
+		.trim()
+		.split('\n')
+		.filter(Boolean)
+		.map((line) => {
+			const [name, device, type] = line.split(':')
+			return {
+				name: name || '',
+				device: device || '',
+				type: type || '',
+			}
+		})
+		.filter((c) => c.name && c.device && c.device !== 'lo')
+}
+
+export async function listNmDevices(): Promise<
+	Array<{ device: string; type: string; state: string; connection: string }>
+> {
+	const stdout = await runUserCmd(
+		'nmcli -t -f DEVICE,TYPE,STATE,CONNECTION device status 2>/dev/null || true'
+	)
+
+	return stdout
+		.trim()
+		.split('\n')
+		.filter(Boolean)
+		.map((line) => {
+			const [device, type, state, connection] = line.split(':')
+			return {
+				device: device || '',
+				type: type || '',
+				state: state || '',
+				connection: connection && connection !== '--' ? connection : '',
+			}
+		})
+		.filter((d) => d.device && d.device !== 'lo')
+}
+
+export async function detectLinuxDnsBackend(): Promise<LinuxDnsBackend> {
+	const hasNmcli = await commandExists('nmcli')
+	if (hasNmcli && (await isServiceActive('NetworkManager'))) {
+		try {
+			const connections = await listNmConnections()
+			if (connections.length > 0) return 'networkmanager'
+		} catch {
+			// fall through
+		}
+	}
+
+	const hasResolvectl = await commandExists('resolvectl')
+	if (
+		hasResolvectl &&
+		((await isServiceActive('systemd-resolved')) ||
+			(await isResolvConfManagedByResolved()))
+	) {
+		return 'systemd-resolved'
+	}
+
+	if (await isResolvConfManagedByResolved()) {
+		if (hasResolvectl) return 'systemd-resolved'
+	}
+
+	return 'resolvconf'
+}
+
+export async function listIpDevices(): Promise<Array<{ device: string; type: string }>> {
+	try {
+		const stdout = await runUserCmd("ls /sys/class/net 2>/dev/null | tr ' ' '\\n'")
+		return stdout
+			.trim()
+			.split('\n')
+			.filter((d) => d && d !== 'lo')
+			.map((device) => ({
+				device,
+				type: /wl|wlan|wifi/i.test(device) ? 'wifi' : 'ethernet',
+			}))
+	} catch {
+		return []
+	}
+}
+
+export async function getDefaultRouteInterface(): Promise<string | null> {
+	try {
+		const stdout = await runUserCmd(
+			"ip -4 route show default 2>/dev/null | awk '{print $5}' | head -n1"
+		)
+		const iface = stdout.trim()
+		return iface || null
+	} catch {
+		return null
+	}
+}

--- a/src/main/platforms/linux/linux.platform.ts
+++ b/src/main/platforms/linux/linux.platform.ts
@@ -1,50 +1,373 @@
+import * as os from 'node:os'
+import { store } from '../../store/store'
 import { Platform } from '../platform'
+import type { Interface } from '../windows/interfaces/interface'
+import {
+	type LinuxConnection,
+	type LinuxDnsBackend,
+	RESOLV_BACKUP_PATH,
+	commandExists,
+	detectLinuxDnsBackend,
+	getDefaultRouteInterface,
+	listIpDevices,
+	listNmConnections,
+	listNmDevices,
+	parseIpv4DnsList,
+	pickPreferredConnection,
+	runUserCmd,
+	shellQuote,
+} from './linux-dns.util'
 
 export class LinuxPlatform extends Platform {
-	async clearDns(): Promise<void> {
+	private backend: LinuxDnsBackend | null = null
+
+	private async getBackend(): Promise<LinuxDnsBackend> {
+		if (!this.backend) {
+			this.backend = await detectLinuxDnsBackend()
+		}
+		return this.backend
+	}
+
+	/** Force re-detect on next call (e.g. after backend command failures). */
+	private resetBackend() {
+		this.backend = null
+	}
+
+	private getConfiguredInterface(): string {
+		return store.get('settings').network_interface || 'Auto'
+	}
+
+	private async resolveNmConnection(): Promise<LinuxConnection> {
+		const connections = await listNmConnections()
+		if (!connections.length) {
+			throw new Error('No active NetworkManager connection found')
+		}
+
+		const configured = this.getConfiguredInterface()
+		if (configured && configured !== 'Auto') {
+			const byDevice = connections.find((c) => c.device === configured)
+			if (byDevice) return byDevice
+
+			const byName = connections.find((c) => c.name === configured)
+			if (byName) return byName
+		}
+
+		const preferred = pickPreferredConnection(connections)
+		if (!preferred) throw new Error('No active NetworkManager connection found')
+		return preferred
+	}
+
+	private async resolveDeviceName(): Promise<string> {
+		const configured = this.getConfiguredInterface()
+		if (configured && configured !== 'Auto') return configured
+
+		const defaultIface = await getDefaultRouteInterface()
+		if (defaultIface) return defaultIface
+
+		const devices = await listIpDevices()
+		if (devices[0]?.device) return devices[0].device
+
+		throw new Error('No network interface found')
+	}
+
+	async setDns(nameServers: Array<string>): Promise<void> {
+		const servers = nameServers.filter(Boolean)
+		if (!servers.length) throw new Error('No DNS servers provided')
+
+		const backend = await this.getBackend()
+
 		try {
-			await this.setDns(['1.1.1.1', '8.8.8.8', '192.168.1.1', '127.0.0.1'])
-		} catch (e) {
-			throw e
+			if (backend === 'networkmanager') {
+				await this.setDnsNetworkManager(servers)
+				return
+			}
+			if (backend === 'systemd-resolved') {
+				await this.setDnsSystemdResolved(servers)
+				return
+			}
+			await this.setDnsResolvConf(servers)
+		} catch (error) {
+			// One retry with fresh detection if the cached backend is stale
+			this.resetBackend()
+			const next = await this.getBackend()
+			if (next === backend) throw error
+
+			if (next === 'networkmanager') {
+				await this.setDnsNetworkManager(servers)
+			} else if (next === 'systemd-resolved') {
+				await this.setDnsSystemdResolved(servers)
+			} else {
+				await this.setDnsResolvConf(servers)
+			}
+		}
+	}
+
+	async clearDns(): Promise<void> {
+		const backend = await this.getBackend()
+
+		try {
+			if (backend === 'networkmanager') {
+				await this.clearDnsNetworkManager()
+				return
+			}
+			if (backend === 'systemd-resolved') {
+				await this.clearDnsSystemdResolved()
+				return
+			}
+			await this.clearDnsResolvConf()
+		} catch (error) {
+			this.resetBackend()
+			const next = await this.getBackend()
+			if (next === backend) throw error
+
+			if (next === 'networkmanager') {
+				await this.clearDnsNetworkManager()
+			} else if (next === 'systemd-resolved') {
+				await this.clearDnsSystemdResolved()
+			} else {
+				await this.clearDnsResolvConf()
+			}
 		}
 	}
 
 	async getActiveDns(): Promise<Array<string>> {
-		try {
-			const cmd = "grep nameserver /etc/resolv.conf | awk '{print $2}'"
-			const text = (await this.execCmd(cmd)) as string
+		const backend = await this.getBackend()
 
-			const regex = /(?<=nameserver\s)\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/g
-			return text.trim().match(regex)
-		} catch (e) {
-			throw e
+		if (backend === 'networkmanager') {
+			const fromNm = await this.getActiveDnsNetworkManager()
+			if (fromNm.length) return fromNm
 		}
+
+		if (backend === 'systemd-resolved' || backend === 'networkmanager') {
+			const fromResolved = await this.getActiveDnsSystemdResolved()
+			if (fromResolved.length) return fromResolved
+		}
+
+		return this.getActiveDnsResolvConf()
 	}
 
-	async getInterfacesList(): Promise<any> {
-		return []
-	}
-
-	async setDns(nameServers: Array<string>): Promise<void> {
+	async getInterfacesList(): Promise<Interface[]> {
 		try {
-			let lines = ''
+			const nmDevices = await listNmDevices()
+			const connected = nmDevices.filter((d) =>
+				d.state.toLowerCase().includes('connected')
+			)
 
-			for (let i = 0; i < nameServers.length; i++) {
-				lines += `nameserver ${nameServers[i]}\n`
+			if (connected.length) {
+				return connected.map((d) => this.toInterface(d.device, d.type))
 			}
-
-			const cmd = `echo '${lines.trim()}' > /etc/resolv.conf`
-			await this.execCmd(cmd)
-
-			const cmdRestart = 'systemctl restart systemd-networkd'
-			await this.execCmd(cmdRestart)
-		} catch (e) {
-			throw e
+		} catch {
+			// fall through to node/os + ip
 		}
+
+		const osIfaces = os.networkInterfaces()
+		const list: Interface[] = []
+
+		for (const [name, addrs] of Object.entries(osIfaces)) {
+			if (!addrs || name === 'lo') continue
+			const ipv4 = addrs.find((a) => a.family === 'IPv4' && !a.internal)
+			if (!ipv4) continue
+			list.push({
+				name,
+				mac_address: ipv4.mac,
+				ip_address: ipv4.address,
+				netmask: ipv4.netmask,
+				type: /wl|wlan|wifi/i.test(name) ? 'Wireless' : 'Wired',
+				vendor: 'Unknown',
+				model: 'Unknown',
+				gateway_ip: null,
+			})
+		}
+
+		if (list.length) {
+			const defaultIface = await getDefaultRouteInterface()
+			if (defaultIface) {
+				for (const item of list) {
+					if (item.name === defaultIface) {
+						item.gateway_ip = 'default'
+					}
+				}
+			}
+			return list
+		}
+
+		const devices = await listIpDevices()
+		return devices.map((d) => this.toInterface(d.device, d.type))
 	}
 
 	public async flushDns(): Promise<void> {
-		await this.execCmd('systemd-resolve --flush-caches')
+		const attempts = [
+			'resolvectl flush-caches',
+			'systemd-resolve --flush-caches',
+			'nscd -i hosts',
+		]
+
+		let flushed = false
+		for (const cmd of attempts) {
+			const bin = cmd.split(' ')[0]
+			if (!(await commandExists(bin))) continue
+			try {
+				await this.execCmd(cmd)
+				flushed = true
+				break
+			} catch {
+				try {
+					await runUserCmd(`${cmd} 2>/dev/null || true`)
+					flushed = true
+					break
+				} catch {
+					// try next
+				}
+			}
+		}
+
+		if (!flushed) {
+			// Best-effort no-op: some distros have no local DNS cache daemon
+			return
+		}
+	}
+
+	// ─── NetworkManager ───────────────────────────────────────────────
+
+	private async setDnsNetworkManager(nameServers: string[]): Promise<void> {
+		const conn = await this.resolveNmConnection()
+		const dns = nameServers.join(' ')
+		const name = shellQuote(conn.name)
+
+		await this.execCmd(
+			`nmcli con mod ${name} ipv4.dns ${shellQuote(dns)} ipv4.ignore-auto-dns yes && nmcli con up ${name}`
+		)
+	}
+
+	private async clearDnsNetworkManager(): Promise<void> {
+		const conn = await this.resolveNmConnection()
+		const name = shellQuote(conn.name)
+
+		await this.execCmd(
+			`nmcli con mod ${name} ipv4.dns "" ipv4.ignore-auto-dns no && nmcli con up ${name}`
+		)
+	}
+
+	private async getActiveDnsNetworkManager(): Promise<string[]> {
+		try {
+			const conn = await this.resolveNmConnection()
+			const stdout = await runUserCmd(
+				`nmcli -t -f IP4.DNS con show ${shellQuote(conn.name)} 2>/dev/null || true`
+			)
+
+			const fromIp4 = stdout
+				.trim()
+				.split('\n')
+				.map((line) => line.split(':').slice(1).join(':').trim())
+				.filter(Boolean)
+
+			if (fromIp4.length) return parseIpv4DnsList(fromIp4.join('\n'))
+
+			// Fallback: configured ipv4.dns (may differ from applied)
+			const configured = await runUserCmd(
+				`nmcli -g ipv4.dns con show ${shellQuote(conn.name)} 2>/dev/null || true`
+			)
+			return parseIpv4DnsList(configured.replace(/\|/g, ' '))
+		} catch {
+			return []
+		}
+	}
+
+	// ─── systemd-resolved ─────────────────────────────────────────────
+
+	private async setDnsSystemdResolved(nameServers: string[]): Promise<void> {
+		const device = await this.resolveDeviceName()
+		const dns = nameServers.map(shellQuote).join(' ')
+		const iface = shellQuote(device)
+
+		await this.execCmd(
+			`resolvectl dns ${iface} ${dns} && resolvectl domain ${iface} '~.'`
+		)
+	}
+
+	private async clearDnsSystemdResolved(): Promise<void> {
+		const device = await this.resolveDeviceName()
+		await this.execCmd(`resolvectl revert ${shellQuote(device)}`)
+	}
+
+	private async getActiveDnsSystemdResolved(): Promise<string[]> {
+		try {
+			const device = await this.resolveDeviceName()
+			const stdout = await runUserCmd(
+				`resolvectl dns ${shellQuote(device)} 2>/dev/null || true`
+			)
+			const parsed = parseIpv4DnsList(stdout)
+			if (parsed.length) return parsed
+
+			const status = await runUserCmd('resolvectl status 2>/dev/null || true')
+			return parseIpv4DnsList(status)
+		} catch {
+			return []
+		}
+	}
+
+	// ─── /etc/resolv.conf fallback ────────────────────────────────────
+
+	private async setDnsResolvConf(nameServers: string[]): Promise<void> {
+		const content = `${nameServers.map((ip) => `nameserver ${ip}`).join('\n')}\n`
+		const payload = Buffer.from(content, 'utf8').toString('base64')
+
+		// Backup once so clearDns can restore DHCP/original resolvers
+		const script = [
+			`if [ ! -f ${shellQuote(RESOLV_BACKUP_PATH)} ]; then`,
+			`  cp -a /etc/resolv.conf ${shellQuote(RESOLV_BACKUP_PATH)} 2>/dev/null || true`,
+			'fi',
+			// If resolv.conf is a symlink, replace with a real file we control
+			'if [ -L /etc/resolv.conf ]; then',
+			'  rm -f /etc/resolv.conf',
+			'fi',
+			`echo ${shellQuote(payload)} | base64 -d > /etc/resolv.conf`,
+		].join('\n')
+
+		await this.execCmd(`bash -c ${shellQuote(script)}`)
+	}
+
+	private async clearDnsResolvConf(): Promise<void> {
+		const script = [
+			`if [ -f ${shellQuote(RESOLV_BACKUP_PATH)} ]; then`,
+			`  cp -a ${shellQuote(RESOLV_BACKUP_PATH)} /etc/resolv.conf`,
+			`  rm -f ${shellQuote(RESOLV_BACKUP_PATH)}`,
+			'elif command -v resolvectl >/dev/null 2>&1; then',
+			"  DEFAULT_IFACE=$(ip -4 route show default 2>/dev/null | awk '{print $5}' | head -n1)",
+			'  if [ -n "$DEFAULT_IFACE" ]; then resolvectl revert "$DEFAULT_IFACE" || true; fi',
+			'else',
+			// Avoid injecting public DNS — let DHCP/network manager recreate config.
+			'  : > /etc/resolv.conf',
+			'fi',
+		].join('\n')
+
+		await this.execCmd(`bash -c ${shellQuote(script)}`)
+	}
+
+	private async getActiveDnsResolvConf(): Promise<string[]> {
+		try {
+			const stdout = await runUserCmd(
+				"grep -E '^nameserver' /etc/resolv.conf 2>/dev/null | awk '{print $2}' || true"
+			)
+			return parseIpv4DnsList(stdout)
+		} catch {
+			return []
+		}
+	}
+
+	private toInterface(device: string, type: string): Interface {
+		const osIfaces = os.networkInterfaces()[device]
+		const ipv4 = osIfaces?.find((a) => a.family === 'IPv4' && !a.internal)
+
+		return {
+			name: device,
+			mac_address: ipv4?.mac,
+			ip_address: ipv4?.address,
+			netmask: ipv4?.netmask ?? null,
+			type: /wifi|wireless|wlan/i.test(type) ? 'Wireless' : 'Wired',
+			vendor: 'Unknown',
+			model: 'Unknown',
+			gateway_ip: null,
+		}
 	}
 }
-// Powered by ChatGpt

--- a/src/renderer/component/cards/server-info/index.tsx
+++ b/src/renderer/component/cards/server-info/index.tsx
@@ -175,9 +175,17 @@ export function ServerInfoCardComponent({ loadingCurrentActive }: Prop) {
 				</div>
 				{/* Stats */}
 				<div className="grid grid-cols-3 gap-3 mt-4">
-					<InfoTile title={window.os.os === 'win32' ? 'Network' : 'Status'}>
+					<InfoTile
+						title={
+							window.os.os === 'win32' || window.os.os === 'linux'
+								? 'Network'
+								: 'Status'
+						}
+					>
 						<div className="text-sm font-medium truncate text-base-content">
-							{window.os.os === 'win32' ? network : 'Ready'}
+							{window.os.os === 'win32' || window.os.os === 'linux'
+								? network
+								: 'Ready'}
 						</div>
 					</InfoTile>
 

--- a/src/renderer/pages/home.page.tsx
+++ b/src/renderer/pages/home.page.tsx
@@ -78,7 +78,9 @@ export function HomePage() {
 						<div className="flex absolute -left-11 -top-6 flex-col gap-2 pt-18.5">
 							<AddCustomDnsButton />
 
-							{osType === 'win32' && <InterfacesDialogButtonComponent />}
+							{(osType === 'win32' || osType === 'linux') && (
+								<InterfacesDialogButtonComponent />
+							)}
 
 							<FlushDNS_BtnComponent />
 


### PR DESCRIPTION
## Summary
- Set and clear DNS on Linux through NetworkManager (`nmcli`) or `systemd-resolved` (`resolvectl`), with a safe `resolv.conf` fallback and real DHCP/auto-DNS restore on disconnect (no more hardcoded public resolvers).
- Expose Linux network interface selection in the UI and improve flush-cache handling across common distros.
- Harden Linux packaging: stable `dnschanger` executable name, correct `.desktop` entry, deb `postinst` (sandbox + PATH symlink), Wayland flags, and install path without spaces.

## Test plan
- [ ] On Ubuntu 22.04/24.04 with NetworkManager: connect to a DNS server, verify `nmcli` shows custom DNS and browsing works; disconnect and confirm auto-DNS/DHCP is restored
- [ ] On a systemd-resolved setup (without NM managing DNS): connect/disconnect via `resolvectl` and confirm revert works
- [ ] Install the `.deb` and confirm launcher starts (`dnschanger` / menu entry), `/usr/bin/dnschanger` exists, and chrome-sandbox permissions are set
- [ ] Smoke-test AppImage launch on Wayland (KDE/GNOME)
- [ ] Confirm interface picker appears on Linux and selecting a device targets the expected connection