### PR TITLE
feat: add DoH and DoT (DNS-over-HTTPS/TLS) support

### DIFF
--- a/src/main/ipc/dialogs.ts
+++ b/src/main/ipc/dialogs.ts
@@ -4,12 +4,11 @@ import pingLib from 'ping'
 import { v4 as uuid } from 'uuid'
 
 import LN from '../../i18n/i18n-node'
-import { Locales } from '../../i18n/i18n-types'
+import type { Locales } from '../../i18n/i18n-types'
 import { EventsKeys } from '../../shared/constants/eventsKeys.constant'
-import { Server, ServerStore } from '../../shared/interfaces/server.interface'
-import { isValidDnsAddress } from '../../shared/validators/dns.validator'
+import type { Server, ServerStore } from '../../shared/interfaces/server.interface'
+import { validateServerAddresses } from '../../shared/validators/dns.validator'
 import { dnsService } from '../config'
-import { WindowsPlatform } from '../platforms/windows/windows.platform'
 import { getOverlayIcon } from '../shared/file'
 import { LogId, getLoggerPathFile, userLogger } from '../shared/logger'
 import { updateOverlayIcon } from '../shared/overlayIcon'
@@ -18,8 +17,7 @@ import { store } from '../store/store'
 
 ipcMain.handle(EventsKeys.SET_DNS, async (event, server: Server) => {
 	try {
-
-		await dnsService.setDns(server.servers)
+		await dnsService.setDns(server)
 		const currentLng = LN[getCurrentLng()]
 		const win = BrowserWindow.getAllWindows()[0]
 		const filepath = await getOverlayIcon(server)
@@ -32,19 +30,18 @@ ipcMain.handle(EventsKeys.SET_DNS, async (event, server: Server) => {
 				currentActive: server.name,
 			}),
 		}
-	} catch (e) {
+	} catch (e: any) {
 		userLogger.error(e.stack, e.message)
 		return {
 			server,
 			success: false,
-			message: 'Unknown error while connecting',
+			message: e?.message || 'Unknown error while connecting',
 		}
 	}
 })
 
 ipcMain.handle(EventsKeys.CLEAR_DNS, async (event, server: Server) => {
 	try {
-
 		await dnsService.clearDns()
 
 		const currentLng = LN[getCurrentLng()]
@@ -54,8 +51,7 @@ ipcMain.handle(EventsKeys.CLEAR_DNS, async (event, server: Server) => {
 		const defaultServer = store.get('defaultServer')
 
 		if (defaultServer) {
-			const servers = defaultServer.servers
-			dnsService.setDns(servers).catch((err) => {
+			dnsService.setDns(defaultServer).catch((err) => {
 				userLogger.error(err.stack, err.message)
 			})
 		}
@@ -65,7 +61,7 @@ ipcMain.handle(EventsKeys.CLEAR_DNS, async (event, server: Server) => {
 			success: true,
 			message: currentLng.pages.home.disconnected(),
 		}
-	} catch (e) {
+	} catch (e: any) {
 		userLogger.error(e.stack, e.message)
 		return { server, success: false, message: 'Unknown error while clear DNS' }
 	}
@@ -76,51 +72,55 @@ ipcMain.handle(EventsKeys.ADD_DNS, async (event, data: Partial<Server>) => {
 		const defaultServer = store.get('defaultServer')
 		const server: Server = {
 			key: 'default',
-			servers: data.servers,
+			servers: data.servers || [],
 			name: 'default',
 			tags: [],
 			avatar: '',
 			rate: 0,
+			protocol: 'plain',
 		}
 
 		if (!defaultServer) {
 			store.set('defaultServer', server)
 		} else {
-			defaultServer.servers = data.servers
+			defaultServer.servers = data.servers || []
 			store.set('defaultServer', defaultServer)
 		}
 
 		return { success: true, server: server }
 	}
 
-	const nameServer1 = data.servers[0]
-	const nameServer2 = data.servers[1]
-	if (!nameServer1) return { success: false, message: 'DNS1 is required' }
-
 	const currentLng = LN[getCurrentLng()]
-
-	if (!isValidDnsAddress(nameServer1))
-		return { success: false, message: currentLng.validator.invalid_dns1 }
-
-	if (nameServer2 && !isValidDnsAddress(nameServer2))
-		return { success: false, message: currentLng.validator.invalid_dns2 }
-
-	if (nameServer1.toString() === nameServer2.toString())
-		return {
-			success: false,
-			message: currentLng.validator.dns1_dns2_duplicates,
+	const validationError = validateServerAddresses(data)
+	if (validationError) {
+		if (validationError.includes('DNS1')) {
+			return { success: false, message: currentLng.validator.invalid_dns1 }
 		}
+		if (validationError.includes('DNS2') || validationError.includes('Alternate')) {
+			return { success: false, message: currentLng.validator.invalid_dns2 }
+		}
+		if (validationError.includes('duplicates')) {
+			return {
+				success: false,
+				message: currentLng.validator.dns1_dns2_duplicates,
+			}
+		}
+		return { success: false, message: validationError }
+	}
 
 	const list: Server[] = store.get('dnsList') || []
 
 	const newServer: ServerStore = {
 		key: data.key || uuid(),
-		name: data.name,
-		avatar: data.avatar,
-		servers: data.servers,
+		name: data.name!,
+		avatar: data.avatar || '',
+		servers: data.servers || [],
 		rate: data.rate || 0,
 		tags: data.tags || [],
 		isPin: false,
+		protocol: data.protocol || 'plain',
+		dohUrl: data.dohUrl,
+		dotHost: data.dotHost,
 	}
 
 	const isDupKey = list.find((s) => s.key === newServer.key)
@@ -145,13 +145,10 @@ ipcMain.handle(EventsKeys.DELETE_DNS, (ev, server: Server) => {
 	}
 })
 
-ipcMain.handle(
-	EventsKeys.RELOAD_SERVER_LIST,
-	async (event, servers: Server[]) => {
-		store.set('dnsList', servers)
-		return { success: true }
-	},
-)
+ipcMain.handle(EventsKeys.RELOAD_SERVER_LIST, async (event, servers: Server[]) => {
+	store.set('dnsList', servers)
+	return { success: true }
+})
 
 ipcMain.handle(EventsKeys.FETCH_DNS_LIST, () => {
 	const servers = store.get('dnsList') || []
@@ -197,7 +194,16 @@ ipcMain.handle(EventsKeys.FLUSHDNS, async () => {
 
 ipcMain.handle(EventsKeys.PING, async (event, server: Server) => {
 	try {
-		const result = await pingLib.promise.probe(server.servers[0], {
+		const target =
+			server.servers?.[0] ||
+			(server.dohUrl ? new URL(server.dohUrl).hostname : null) ||
+			server.dotHost?.split(':')[0]
+
+		if (!target) {
+			return { success: false }
+		}
+
+		const result = await pingLib.promise.probe(target, {
 			timeout: 10,
 		})
 		return {
@@ -243,13 +249,38 @@ async function getCurrentActive(): Promise<{
 	message?: string
 }> {
 	try {
+		const encrypted = dnsService.getActiveEncryptedConnection()
+		if (encrypted) {
+			const servers = store.get('dnsList') || []
+			const server = servers.find((item) => item.key === encrypted.key)
+			if (server) {
+				const win = BrowserWindow.getAllWindows()[0]
+				const filepath = await getOverlayIcon(server)
+				updateOverlayIcon(win, filepath, 'connected')
+				return { success: true, server }
+			}
+			return {
+				success: true,
+				server: {
+					key: encrypted.key,
+					name: encrypted.protocol.toUpperCase(),
+					servers: encrypted.bootstrap,
+					protocol: encrypted.protocol,
+					dohUrl: encrypted.dohUrl,
+					dotHost: encrypted.dotHost,
+					avatar: '',
+					isPin: false,
+				},
+			}
+		}
+
 		const dns: string[] = await dnsService.getActiveDns()
 
 		if (!dns.length) return { success: false, server: null }
 
 		const servers = store.get('dnsList') || []
 		const server: ServerStore | null = servers.find(
-			(server) => server.servers.toString() === dns.toString(),
+			(server) => server.servers.toString() === dns.toString()
 		)
 		const defaultServer = store.get('defaultServer')
 		if (defaultServer) {
@@ -285,7 +316,7 @@ async function getCurrentActive(): Promise<{
 		updateOverlayIcon(win, filepath, 'connected')
 
 		return { success: true, server }
-	} catch (e) {
+	} catch (e: any) {
 		userLogger.error(e.stack, e.message)
 		return { success: false, message: 'Unknown error while clear DNS' }
 	}

--- a/src/main/services/dns.service.ts
+++ b/src/main/services/dns.service.ts
@@ -1,10 +1,31 @@
-import { Platform } from '../platforms/platform'
+import type { Server } from '../../shared/interfaces/server.interface'
+import {
+	getServerProtocol,
+	isEncryptedDns,
+} from '../../shared/interfaces/server.interface'
+import type { Platform } from '../platforms/platform'
+import { EncryptedDnsService } from './encrypted-dns/encrypted-dns.service'
 
 export class DnsService {
-	constructor(private platform: Platform) {}
+	private encryptedDns: EncryptedDnsService
 
-	async setDns(nameServers: Array<string>) {
-		return this.platform.setDns(nameServers)
+	constructor(private platform: Platform) {
+		this.encryptedDns = new EncryptedDnsService(platform)
+	}
+
+	async setDns(server: Server | string[]) {
+		// Backward-compatible: string[] = plaintext nameservers
+		if (Array.isArray(server)) {
+			await this.encryptedDns.disconnect({ restoreSystemDns: false })
+			return this.platform.setDns(server)
+		}
+
+		if (isEncryptedDns(server)) {
+			return this.encryptedDns.connect(server)
+		}
+
+		await this.encryptedDns.disconnect({ restoreSystemDns: false })
+		return this.platform.setDns(server.servers)
 	}
 
 	async getActiveDns() {
@@ -12,7 +33,16 @@ export class DnsService {
 	}
 
 	async clearDns() {
+		const active = this.encryptedDns.getActiveConnection()
+		if (active) {
+			await this.encryptedDns.disconnect({ restoreSystemDns: true })
+			return
+		}
 		return this.platform.clearDns()
+	}
+
+	getActiveEncryptedConnection() {
+		return this.encryptedDns.getActiveConnection()
 	}
 
 	async getInterfacesList() {
@@ -21,5 +51,13 @@ export class DnsService {
 
 	async flushDns() {
 		return this.platform.flushDns()
+	}
+
+	isEncrypted(server: Server) {
+		return isEncryptedDns(server)
+	}
+
+	getProtocol(server: Server) {
+		return getServerProtocol(server)
 	}
 }

--- a/src/main/services/encrypted-dns/encrypted-dns.service.ts
+++ b/src/main/services/encrypted-dns/encrypted-dns.service.ts
@@ -1,0 +1,277 @@
+import sudo from '@vscode/sudo-prompt'
+import type { ActiveEncryptedConnection } from '../../../shared/interfaces/encrypted-dns.interface'
+import type { Server } from '../../../shared/interfaces/server.interface'
+import {
+	getServerProtocol,
+	isEncryptedDns,
+} from '../../../shared/interfaces/server.interface'
+import type { Platform } from '../../platforms/platform'
+import { userLogger } from '../../shared/logger'
+import { store } from '../../store/store'
+import { LocalDnsProxy } from './local-dns-proxy'
+
+const LOCAL_STUB = '127.0.0.1'
+
+function execElevated(cmd: string): Promise<string> {
+	return new Promise((resolve, reject) => {
+		sudo.exec(cmd, { name: 'dnsChanger' }, (error, stdout) => {
+			if (error) {
+				reject(error)
+				return
+			}
+			resolve(String(stdout ?? ''))
+		})
+	})
+}
+
+/**
+ * Applies DoH / DoT using OS-native APIs when available, otherwise a local
+ * UDP stub on 127.0.0.1:53 that forwards to the encrypted upstream.
+ */
+export class EncryptedDnsService {
+	private proxy: LocalDnsProxy | null = null
+
+	constructor(private platform: Platform) {}
+
+	getActiveConnection(): ActiveEncryptedConnection | null {
+		return store.get('activeEncryptedConnection') || null
+	}
+
+	async connect(server: Server): Promise<void> {
+		const protocol = getServerProtocol(server)
+		if (protocol !== 'doh' && protocol !== 'dot') {
+			throw new Error('Server is not configured for encrypted DNS')
+		}
+
+		await this.disconnect({ restoreSystemDns: false })
+
+		if (protocol === 'doh' && process.platform === 'win32') {
+			await this.connectWindowsDoh(server)
+			return
+		}
+
+		if (protocol === 'dot' && process.platform === 'linux') {
+			const usedNative = await this.tryConnectLinuxDot(server)
+			if (usedNative) return
+		}
+
+		await this.connectViaProxy(server)
+	}
+
+	async disconnect(options?: { restoreSystemDns?: boolean }): Promise<void> {
+		const restoreSystemDns = options?.restoreSystemDns !== false
+		const active = this.getActiveConnection()
+
+		if (this.proxy) {
+			try {
+				await this.proxy.stop()
+			} catch (error) {
+				userLogger.error(
+					error instanceof Error ? error.stack : String(error),
+					'Failed to stop local DNS proxy'
+				)
+			}
+			this.proxy = null
+		}
+
+		if (active?.mode === 'native' && process.platform === 'win32') {
+			await this.clearWindowsDoh(active.bootstrap)
+		}
+
+		if (active?.mode === 'native' && process.platform === 'linux') {
+			await this.clearLinuxDot()
+		}
+
+		store.set('activeEncryptedConnection', null)
+
+		if (restoreSystemDns) {
+			await this.platform.clearDns()
+		}
+	}
+
+	private async connectWindowsDoh(server: Server): Promise<void> {
+		const bootstrap = (server.servers || []).filter(Boolean)
+		if (!bootstrap.length) {
+			await this.connectViaProxy(server)
+			return
+		}
+
+		const template = server.dohUrl || `https://${this.hostFromDoh(server)}/dns-query`
+		const dothost = this.hostFromUrlOrDot(template, server.dotHost)
+
+		for (const ip of bootstrap) {
+			const cmd = `netsh dns add encryption server=${ip} dothost=${dothost} autoupgrade=yes dohtemplate=${template}`
+			try {
+				await execElevated(cmd)
+			} catch (error) {
+				userLogger.error(
+					error instanceof Error ? error.stack : String(error),
+					`Windows DoH encryption register failed for ${ip}`
+				)
+			}
+		}
+
+		await this.platform.setDns(bootstrap)
+
+		store.set('activeEncryptedConnection', {
+			key: server.key,
+			protocol: 'doh',
+			mode: 'native',
+			dohUrl: template,
+			bootstrap,
+		})
+	}
+
+	private async clearWindowsDoh(bootstrap: string[]): Promise<void> {
+		for (const ip of bootstrap) {
+			try {
+				await execElevated(`netsh dns delete encryption server=${ip}`)
+			} catch {
+				// ignore missing encryption records
+			}
+		}
+	}
+
+	private async tryConnectLinuxDot(server: Server): Promise<boolean> {
+		const bootstrap = (server.servers || []).filter(Boolean)
+		const host = server.dotHost
+		if (!bootstrap.length || !host) return false
+
+		try {
+			const nmCheck = await execElevated(
+				'command -v nmcli >/dev/null 2>&1 && echo yes || echo no'
+			)
+			if (!nmCheck.trim().includes('yes')) return false
+
+			const connOut = await execElevated(
+				'nmcli -t -f NAME,DEVICE,TYPE con show --active | head -n1'
+			)
+			const connName = connOut.trim().split(':')[0]
+			if (!connName) return false
+
+			const quoted = connName.replace(/'/g, `'\\''`)
+			const dns = bootstrap.join(' ')
+			await execElevated(
+				`nmcli con mod '${quoted}' ipv4.dns '${dns}' ipv4.ignore-auto-dns yes connection.dns-over-tls 2 && nmcli con up '${quoted}'`
+			)
+
+			try {
+				await execElevated(
+					`IFACE=$(ip -4 route show default | awk '{print $5}' | head -n1); resolvectl dns "$IFACE" ${bootstrap[0]}#${host}; resolvectl dnsovertls "$IFACE" yes`
+				)
+			} catch {
+				// optional SNI path
+			}
+
+			store.set('activeEncryptedConnection', {
+				key: server.key,
+				protocol: 'dot',
+				mode: 'native',
+				dotHost: host,
+				bootstrap,
+			})
+			return true
+		} catch (error) {
+			userLogger.error(
+				error instanceof Error ? error.stack : String(error),
+				'Linux native DoT failed; falling back to local proxy'
+			)
+			return false
+		}
+	}
+
+	private async clearLinuxDot(): Promise<void> {
+		try {
+			const connOut = await execElevated(
+				'nmcli -t -f NAME con show --active 2>/dev/null | head -n1 || true'
+			)
+			const connName = connOut.trim()
+			if (!connName) return
+			const quoted = connName.replace(/'/g, `'\\''`)
+			await execElevated(
+				`nmcli con mod '${quoted}' connection.dns-over-tls 0 ipv4.dns "" ipv4.ignore-auto-dns no && nmcli con up '${quoted}'`
+			)
+		} catch {
+			// clearDns() will still run
+		}
+	}
+
+	private async connectViaProxy(server: Server): Promise<void> {
+		const protocol = getServerProtocol(server)
+		if (protocol !== 'doh' && protocol !== 'dot') {
+			throw new Error('Invalid encrypted protocol')
+		}
+
+		const upstream =
+			protocol === 'doh'
+				? { kind: 'doh' as const, url: server.dohUrl! }
+				: {
+						kind: 'dot' as const,
+						host: server.dotHost!.split(':')[0],
+						port: server.dotHost!.includes(':')
+							? Number(server.dotHost!.split(':')[1])
+							: 853,
+						servername: server.dotHost!.split(':')[0],
+					}
+
+		const proxy = new LocalDnsProxy(upstream, {
+			host: LOCAL_STUB,
+			port: 53,
+		})
+
+		try {
+			await proxy.start()
+		} catch (error: any) {
+			if (error?.code === 'EACCES' || error?.code === 'EADDRINUSE') {
+				throw new Error(
+					'Could not bind 127.0.0.1:53 for encrypted DNS. Close other local DNS stubs or run the app with elevated privileges.'
+				)
+			}
+			throw error
+		}
+
+		this.proxy = proxy
+		await this.platform.setDns([LOCAL_STUB])
+
+		store.set('activeEncryptedConnection', {
+			key: server.key,
+			protocol,
+			mode: 'proxy',
+			dohUrl: server.dohUrl,
+			dotHost: server.dotHost,
+			bootstrap: [LOCAL_STUB],
+		})
+	}
+
+	private hostFromDoh(server: Server): string {
+		if (server.dotHost) return server.dotHost.split(':')[0]
+		if (server.dohUrl) {
+			try {
+				return new URL(server.dohUrl).hostname
+			} catch {
+				return 'dns.example'
+			}
+		}
+		return 'dns.example'
+	}
+
+	private hostFromUrlOrDot(url: string, dotHost?: string): string {
+		if (dotHost) return dotHost.split(':')[0]
+		try {
+			return new URL(url).hostname
+		} catch {
+			return 'dns.example'
+		}
+	}
+}
+
+export function assertEncryptedServer(server: Server): void {
+	if (!isEncryptedDns(server)) return
+	const protocol = getServerProtocol(server)
+	if (protocol === 'doh' && !server.dohUrl) {
+		throw new Error('DoH URL is required')
+	}
+	if (protocol === 'dot' && !server.dotHost) {
+		throw new Error('DoT hostname is required')
+	}
+}

--- a/src/main/services/encrypted-dns/local-dns-proxy.ts
+++ b/src/main/services/encrypted-dns/local-dns-proxy.ts
@@ -1,0 +1,172 @@
+import dgram from 'node:dgram'
+import http from 'node:http'
+import https from 'node:https'
+import tls from 'node:tls'
+import { URL } from 'node:url'
+import { userLogger } from '../../shared/logger'
+
+export type ProxyUpstream =
+	| { kind: 'doh'; url: string }
+	| { kind: 'dot'; host: string; port?: number; servername?: string }
+
+/**
+ * Minimal UDP DNS stub that forwards queries to a DoH or DoT upstream.
+ * Intended to listen on 127.0.0.1:53 while the OS points at localhost.
+ */
+export class LocalDnsProxy {
+	private socket: dgram.Socket | null = null
+	private readonly upstream: ProxyUpstream
+	private readonly listenHost: string
+	private readonly listenPort: number
+
+	constructor(upstream: ProxyUpstream, options?: { host?: string; port?: number }) {
+		this.upstream = upstream
+		this.listenHost = options?.host ?? '127.0.0.1'
+		this.listenPort = options?.port ?? 53
+	}
+
+	get address() {
+		return { host: this.listenHost, port: this.listenPort }
+	}
+
+	async start(): Promise<void> {
+		if (this.socket) return
+
+		const socket = dgram.createSocket('udp4')
+		this.socket = socket
+
+		socket.on('message', (msg, rinfo) => {
+			this.forward(msg)
+				.then((response) => {
+					if (!response?.length) return
+					socket.send(response, rinfo.port, rinfo.address)
+				})
+				.catch((error) => {
+					userLogger.error(
+						error instanceof Error ? error.stack : String(error),
+						'LocalDnsProxy forward failed'
+					)
+				})
+		})
+
+		await new Promise<void>((resolve, reject) => {
+			const onError = (error: Error) => {
+				socket.close()
+				this.socket = null
+				reject(error)
+			}
+			socket.once('error', onError)
+			socket.bind(this.listenPort, this.listenHost, () => {
+				socket.off('error', onError)
+				resolve()
+			})
+		})
+	}
+
+	async stop(): Promise<void> {
+		const socket = this.socket
+		this.socket = null
+		if (!socket) return
+
+		await new Promise<void>((resolve) => {
+			socket.close(() => resolve())
+		})
+	}
+
+	private async forward(query: Buffer): Promise<Buffer> {
+		if (this.upstream.kind === 'doh') {
+			return this.forwardDoh(query, this.upstream.url)
+		}
+		return this.forwardDot(
+			query,
+			this.upstream.host,
+			this.upstream.port ?? 853,
+			this.upstream.servername ?? this.upstream.host
+		)
+	}
+
+	private forwardDoh(query: Buffer, dohUrl: string): Promise<Buffer> {
+		const url = new URL(dohUrl)
+		const transport = url.protocol === 'http:' ? http : https
+
+		return new Promise((resolve, reject) => {
+			const req = transport.request(
+				{
+					protocol: url.protocol,
+					hostname: url.hostname,
+					port: url.port || (url.protocol === 'http:' ? 80 : 443),
+					path: `${url.pathname}${url.search}`,
+					method: 'POST',
+					headers: {
+						'content-type': 'application/dns-message',
+						accept: 'application/dns-message',
+						'content-length': query.length,
+					},
+					timeout: 8_000,
+				},
+				(res) => {
+					const chunks: Buffer[] = []
+					res.on('data', (chunk) => chunks.push(chunk))
+					res.on('end', () => {
+						if ((res.statusCode || 0) >= 400) {
+							reject(
+								new Error(`DoH upstream returned HTTP ${res.statusCode}`)
+							)
+							return
+						}
+						resolve(Buffer.concat(chunks))
+					})
+				}
+			)
+			req.on('error', reject)
+			req.on('timeout', () => {
+				req.destroy(new Error('DoH upstream timeout'))
+			})
+			req.write(query)
+			req.end()
+		})
+	}
+
+	private forwardDot(
+		query: Buffer,
+		host: string,
+		port: number,
+		servername: string
+	): Promise<Buffer> {
+		return new Promise((resolve, reject) => {
+			const socket = tls.connect(
+				{
+					host,
+					port,
+					servername,
+					timeout: 8_000,
+				},
+				() => {
+					const len = Buffer.alloc(2)
+					len.writeUInt16BE(query.length, 0)
+					socket.write(Buffer.concat([len, query]))
+				}
+			)
+
+			let buffer = Buffer.alloc(0)
+			let expected = -1
+
+			socket.on('data', (chunk) => {
+				buffer = Buffer.concat([buffer, chunk])
+				if (expected < 0 && buffer.length >= 2) {
+					expected = buffer.readUInt16BE(0)
+					buffer = buffer.subarray(2)
+				}
+				if (expected >= 0 && buffer.length >= expected) {
+					const response = buffer.subarray(0, expected)
+					socket.end()
+					resolve(response)
+				}
+			})
+			socket.on('error', reject)
+			socket.on('timeout', () => {
+				socket.destroy(new Error('DoT upstream timeout'))
+			})
+		})
+	}
+}

--- a/src/main/store/store.ts
+++ b/src/main/store/store.ts
@@ -1,7 +1,7 @@
 import electronStore from 'electron-store'
 
 import { serversConstant } from '../../shared/constants/servers.cosntant'
-import { StoreKey } from '../../shared/interfaces/settings.interface'
+import type { StoreKey } from '../../shared/interfaces/settings.interface'
 import { defaultSetting } from '../../shared/constants/default-setting.contant'
 
 export const store = new electronStore<StoreKey>({
@@ -9,6 +9,7 @@ export const store = new electronStore<StoreKey>({
 		dnsList: serversConstant,
 		settings: defaultSetting,
 		defaultServer: null,
+		activeEncryptedConnection: null,
 	},
 	name: 'dnsChangerStore_1.9.0',
 })

--- a/src/renderer/component/cards/server-info/index.tsx
+++ b/src/renderer/component/cards/server-info/index.tsx
@@ -150,7 +150,11 @@ export function ServerInfoCardComponent({ loadingCurrentActive }: Prop) {
 							</div>
 
 							<p className="text-xs text-base-content/50">
-								Public DNS Server
+								{servers.selected.protocol === 'doh'
+									? 'DNS-over-HTTPS'
+									: servers.selected.protocol === 'dot'
+										? 'DNS-over-TLS'
+										: 'Public DNS Server'}
 							</p>
 						</div>
 					</div>
@@ -202,17 +206,29 @@ export function ServerInfoCardComponent({ loadingCurrentActive }: Prop) {
 					</InfoTile>
 
 					<InfoTile
-						title="DNS"
+						title={
+							servers.selected.protocol === 'doh'
+								? 'DoH'
+								: servers.selected.protocol === 'dot'
+									? 'DoT'
+									: 'DNS'
+						}
 						action={
 							copied ? (
 								<span className="text-xs text-success">Copied</span>
 							) : (
 								<button
 									onClick={() => {
-										navigator.clipboard.writeText(
-											servers.selected?.servers?.join(', ') || ''
-										)
+										const text =
+											servers.selected?.protocol === 'doh'
+												? servers.selected.dohUrl || ''
+												: servers.selected?.protocol === 'dot'
+													? servers.selected.dotHost || ''
+													: servers.selected?.servers?.join(
+															', '
+														) || ''
 
+										navigator.clipboard.writeText(text)
 										setCopied(true)
 									}}
 									className="p-1 transition-colors rounded cursor-pointer hover:bg-base-300/60"
@@ -223,13 +239,23 @@ export function ServerInfoCardComponent({ loadingCurrentActive }: Prop) {
 						}
 					>
 						<div className="text-sm font-medium truncate">
-							{servers.selected.servers[0]}
+							{servers.selected.protocol === 'doh'
+								? servers.selected.dohUrl
+								: servers.selected.protocol === 'dot'
+									? servers.selected.dotHost
+									: servers.selected.servers[0]}
 						</div>
 					</InfoTile>
 				</div>
 
 				<div className="flex items-center justify-between pt-3 mt-auto text-xs text-base-content/40">
-					<span>{servers.selected.type ?? 'DNS Server'}</span>
+					<span>
+						{servers.selected.protocol === 'doh'
+							? 'DoH Server'
+							: servers.selected.protocol === 'dot'
+								? 'DoT Server'
+								: (servers.selected.type ?? 'DNS Server')}
+					</span>
 					<div className="flex items-center gap-1">
 						<DeleteButtonComponent />
 						<ToggleButtonComponent />

--- a/src/renderer/component/modals/add-dns.component.tsx
+++ b/src/renderer/component/modals/add-dns.component.tsx
@@ -1,14 +1,14 @@
 import type React from 'react'
 import { useEffect, useState } from 'react'
 
-import type { setState } from '../../interfaces/react.interface'
 import { useI18nContext } from '../../../i18n/i18n-react'
-
+import type { DnsProtocol } from '../../../shared/interfaces/server.interface'
+import type { setState } from '../../interfaces/react.interface'
 import { appNotif } from '../../notifications/appNotif'
-import Modal from './modal'
-import { TabNavigation } from '../tab/tab-navigation'
-import { TextInput } from '../input/text-input'
 import { Button } from '../button/button'
+import { TextInput } from '../input/text-input'
+import { TabNavigation } from '../tab/tab-navigation'
+import Modal from './modal'
 
 interface Props {
 	isOpen: boolean
@@ -18,11 +18,16 @@ interface Props {
 
 const ipv4Pattern = /^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$/
 
+type TabType = 'ipv4' | 'doh' | 'dot' | 'default'
+
 export function AddDnsModalComponent(props: Props) {
 	const [serverName, setServerName] = useState<string>('')
 	const [validationMessage, setValidationMessage] = useState<string>('')
+	const [dohUrl, setDohUrl] = useState('https://')
+	const [dotHost, setDotHost] = useState('')
+	const [bootstrapIp, setBootstrapIp] = useState('')
 
-	const [type, setType] = useState<'ipv4' | 'default'>('ipv4')
+	const [type, setType] = useState<TabType>('ipv4')
 	const { LL } = useI18nContext()
 
 	useEffect(() => {
@@ -33,7 +38,6 @@ export function AddDnsModalComponent(props: Props) {
 			setDNSAddressToInput('def-serverInput-2', defServer.servers[1])
 		}
 
-		// fetch from clipboard
 		navigator.clipboard.readText().then(clipboardHandler)
 
 		setValidationMessage('')
@@ -61,7 +65,36 @@ export function AddDnsModalComponent(props: Props) {
 				resp = await window.ipc.addDns({
 					name: 'default',
 					servers: [nameServer1Default, nameServer2Default],
+					protocol: 'plain',
 				})
+			} else if (type === 'doh' || type === 'dot') {
+				if (!serverName) {
+					setValidationMessage('Server name cannot be empty')
+					return
+				}
+				if (serverName === 'default') {
+					return appNotif('Error', 'Server name cannot be "default"', 'ERROR')
+				}
+
+				const protocol: DnsProtocol = type
+				const servers =
+					bootstrapIp && ipv4Pattern.test(bootstrapIp) ? [bootstrapIp] : []
+
+				if (type === 'doh') {
+					resp = await window.ipc.addDns({
+						name: serverName,
+						servers,
+						protocol,
+						dohUrl: dohUrl.trim(),
+					})
+				} else {
+					resp = await window.ipc.addDns({
+						name: serverName,
+						servers,
+						protocol,
+						dotHost: dotHost.trim(),
+					})
+				}
 			} else {
 				if (!serverName)
 					return setValidationMessage('Server name cannot be empty')
@@ -75,7 +108,6 @@ export function AddDnsModalComponent(props: Props) {
 				}
 
 				const nameServer2 = getNameServer('serverInput-2')
-				console.log('nameServer2', nameServer2, ipv4Pattern.test(nameServer2))
 				if (nameServer2 && !ipv4Pattern.test(nameServer2)) {
 					setValidationMessage(`Invalid DNS Address ${nameServer2}`)
 					return
@@ -84,6 +116,7 @@ export function AddDnsModalComponent(props: Props) {
 				resp = await window.ipc.addDns({
 					name: serverName,
 					servers: [nameServer1, nameServer2],
+					protocol: 'plain',
 				})
 			}
 
@@ -104,6 +137,9 @@ export function AddDnsModalComponent(props: Props) {
 				}
 
 				setServerName('')
+				setDohUrl('https://')
+				setDotHost('')
+				setBootstrapIp('')
 
 				if (resp.server.name !== 'default') props.cb(resp.server)
 			} else {
@@ -116,9 +152,7 @@ export function AddDnsModalComponent(props: Props) {
 
 	async function onChange(e: React.ChangeEvent<HTMLInputElement>) {
 		const value = e.target.value
-		// validate value is a DNS Address
 		if (!value) {
-			//back to previous input
 			const prevInput: any = e.target.previousElementSibling
 			if (!prevInput) return
 			if (prevInput.tagName === 'SPAN' && prevInput.previousElementSibling) {
@@ -141,7 +175,6 @@ export function AddDnsModalComponent(props: Props) {
 			const nextInput: any = e.target.nextElementSibling
 			if (!nextInput) return
 
-			// ignore "." element
 			if (nextInput.tagName === 'SPAN' && nextInput.nextElementSibling) {
 				nextInput.nextElementSibling.focus()
 				return
@@ -180,6 +213,12 @@ export function AddDnsModalComponent(props: Props) {
 	function clipboardHandler(clipText: string | null) {
 		if (!clipText) return
 
+		if (clipText.startsWith('https://')) {
+			setType('doh')
+			setDohUrl(clipText.trim())
+			return
+		}
+
 		if (!clipText.includes('.')) return
 
 		let servers = clipText.split(',') as string[]
@@ -214,19 +253,21 @@ export function AddDnsModalComponent(props: Props) {
 			<div className="flex flex-col gap-2 py-2">
 				<TabNavigation
 					tabs={[
-						{
-							id: 'ipv4',
-							label: 'IPV4',
-						},
-						{
-							id: 'Default',
-							label: 'Default',
-						},
+						{ id: 'ipv4', label: 'IPv4' },
+						{ id: 'doh', label: 'DoH' },
+						{ id: 'dot', label: 'DoT' },
+						{ id: 'default', label: 'Default' },
 					]}
 					activeTab={type}
 					tabMode="simple"
-					onTabClick={(val) => setType(val as any)}
+					onTabClick={(val) => setType(val as TabType)}
 				/>
+
+				{validationMessage && (
+					<div className="text-[12px] alert alert-error font-[Inter] text-center flex items-center">
+						{validationMessage}
+					</div>
+				)}
 
 				{type === 'ipv4' ? (
 					<div className={'px-2 flex flex-col gap-y-2'}>
@@ -242,12 +283,6 @@ export function AddDnsModalComponent(props: Props) {
 						</div>
 
 						<div className={'flex flex-col h-full w-full'}>
-							{validationMessage && (
-								<div className="text-[12px] alert alert-error font-[Inter] h-2 text-center flex items-center">
-									{validationMessage}
-								</div>
-							)}
-
 							<div className="flex flex-row items-center justify-between w-full gap-2 mt-2">
 								<span className="text-gray-700 font-[balooTamma] dark:text-gray-300 text-[12px]">
 									Preferred DNS server:
@@ -272,7 +307,70 @@ export function AddDnsModalComponent(props: Props) {
 							</div>
 						</div>
 					</div>
-				) : (
+				) : null}
+
+				{type === 'doh' ? (
+					<div className="flex flex-col gap-2 px-2">
+						<p className="text-[12px] dark:text-gray-400 font-[Inter] bg-[#f2f2f2] dark:bg-[#262626] p-2 rounded-md">
+							DNS-over-HTTPS endpoint (e.g. AdGuard Home:
+							https://example.com/dns-query)
+						</p>
+						<span className="label-text text-lg font-[balooTamma]">Name</span>
+						<TextInput
+							onChange={setServerName}
+							value={serverName}
+							placeholder="My DoH server"
+						/>
+						<span className="label-text text-lg font-[balooTamma]">
+							DoH URL
+						</span>
+						<TextInput
+							onChange={setDohUrl}
+							value={dohUrl}
+							placeholder="https://dns.example/dns-query"
+						/>
+						<span className="label-text text-lg font-[balooTamma]">
+							Bootstrap IP (optional)
+						</span>
+						<TextInput
+							onChange={setBootstrapIp}
+							value={bootstrapIp}
+							placeholder="1.1.1.1"
+						/>
+					</div>
+				) : null}
+
+				{type === 'dot' ? (
+					<div className="flex flex-col gap-2 px-2">
+						<p className="text-[12px] dark:text-gray-400 font-[Inter] bg-[#f2f2f2] dark:bg-[#262626] p-2 rounded-md">
+							DNS-over-TLS hostname on port 853 (host or host:port)
+						</p>
+						<span className="label-text text-lg font-[balooTamma]">Name</span>
+						<TextInput
+							onChange={setServerName}
+							value={serverName}
+							placeholder="My DoT server"
+						/>
+						<span className="label-text text-lg font-[balooTamma]">
+							DoT hostname
+						</span>
+						<TextInput
+							onChange={setDotHost}
+							value={dotHost}
+							placeholder="dns.example.com"
+						/>
+						<span className="label-text text-lg font-[balooTamma]">
+							Bootstrap IP (optional)
+						</span>
+						<TextInput
+							onChange={setBootstrapIp}
+							value={bootstrapIp}
+							placeholder="1.1.1.1"
+						/>
+					</div>
+				) : null}
+
+				{type === 'default' ? (
 					<div>
 						<div className={'grid'}>
 							<div>
@@ -319,7 +417,7 @@ export function AddDnsModalComponent(props: Props) {
 							</div>
 						</div>
 					</div>
-				)}
+				) : null}
 
 				<div className="flex flex-row gap-2">
 					<Button

--- a/src/shared/constants/servers.cosntant.ts
+++ b/src/shared/constants/servers.cosntant.ts
@@ -1,4 +1,4 @@
-import { Server, ServerStore } from '../interfaces/server.interface'
+import type { ServerStore } from '../interfaces/server.interface'
 
 export const serversConstant: Array<ServerStore> = [
 	{
@@ -9,6 +9,7 @@ export const serversConstant: Array<ServerStore> = [
 		rate: 10,
 		tags: ['Gaming', 'Web', 'Ai'],
 		isPin: false,
+		protocol: 'plain',
 	},
 	{
 		key: 'ELECTRO',
@@ -18,6 +19,7 @@ export const serversConstant: Array<ServerStore> = [
 		rate: 9,
 		tags: ['Gaming', 'Web', 'Ai'],
 		isPin: false,
+		protocol: 'plain',
 	},
 	{
 		key: 'RADAR_GAME',
@@ -27,8 +29,8 @@ export const serversConstant: Array<ServerStore> = [
 		rate: 5,
 		tags: ['Gaming'],
 		isPin: false,
+		protocol: 'plain',
 	},
-
 	{
 		key: 'ClOUD_FLARE',
 		name: 'Cloudflare',
@@ -37,5 +39,41 @@ export const serversConstant: Array<ServerStore> = [
 		rate: 0,
 		tags: ['Web'],
 		isPin: false,
+		protocol: 'plain',
+	},
+	{
+		key: 'CLOUDFLARE_DOH',
+		name: 'Cloudflare DoH',
+		servers: ['1.1.1.1', '1.0.0.1'],
+		avatar: 'cloudflare.png',
+		rate: 0,
+		tags: ['Web', 'DoH'],
+		isPin: false,
+		protocol: 'doh',
+		dohUrl: 'https://cloudflare-dns.com/dns-query',
+		dotHost: 'cloudflare-dns.com',
+	},
+	{
+		key: 'CLOUDFLARE_DOT',
+		name: 'Cloudflare DoT',
+		servers: ['1.1.1.1', '1.0.0.1'],
+		avatar: 'cloudflare.png',
+		rate: 0,
+		tags: ['Web', 'DoT'],
+		isPin: false,
+		protocol: 'dot',
+		dotHost: 'cloudflare-dns.com',
+	},
+	{
+		key: 'QUAD9_DOH',
+		name: 'Quad9 DoH',
+		servers: ['9.9.9.9', '149.112.112.112'],
+		avatar: 'def.png',
+		rate: 0,
+		tags: ['Web', 'DoH'],
+		isPin: false,
+		protocol: 'doh',
+		dohUrl: 'https://dns.quad9.net/dns-query',
+		dotHost: 'dns.quad9.net',
 	},
 ]

--- a/src/shared/interfaces/encrypted-dns.interface.ts
+++ b/src/shared/interfaces/encrypted-dns.interface.ts
@@ -1,0 +1,8 @@
+export type ActiveEncryptedConnection = {
+	key: string
+	protocol: 'doh' | 'dot'
+	mode: 'native' | 'proxy'
+	dohUrl?: string
+	dotHost?: string
+	bootstrap: string[]
+}

--- a/src/shared/interfaces/server.interface.ts
+++ b/src/shared/interfaces/server.interface.ts
@@ -1,11 +1,30 @@
+export type DnsProtocol = 'plain' | 'doh' | 'dot'
+
 export interface Server extends Record<string, any> {
 	key: string
 	name: string
+	/** Bootstrap / plaintext nameserver IPs (also used by native DoH/DoT APIs). */
 	servers: string[]
 	avatar: string
 	rate: number
 	tags: string[]
+	/** Defaults to plain when omitted (backward compatible with catalog). */
+	protocol?: DnsProtocol
+	/** DoH template, e.g. https://cloudflare-dns.com/dns-query */
+	dohUrl?: string
+	/** DoT hostname / SNI, e.g. cloudflare-dns.com or AdGuard host */
+	dotHost?: string
 }
+
 export interface ServerStore extends Server {
 	isPin: boolean
+}
+
+export function getServerProtocol(server: Pick<Server, 'protocol'>): DnsProtocol {
+	return server.protocol || 'plain'
+}
+
+export function isEncryptedDns(server: Pick<Server, 'protocol'>): boolean {
+	const protocol = getServerProtocol(server)
+	return protocol === 'doh' || protocol === 'dot'
 }

--- a/src/shared/interfaces/settings.interface.ts
+++ b/src/shared/interfaces/settings.interface.ts
@@ -1,5 +1,6 @@
-import { Locales } from '../../i18n/i18n-types'
-import { ServerStore } from './server.interface'
+import type { Locales } from '../../i18n/i18n-types'
+import type { ActiveEncryptedConnection } from './encrypted-dns.interface'
+import type { ServerStore } from './server.interface'
 
 export interface Settings {
 	startUp: boolean
@@ -16,4 +17,5 @@ export type StoreKey = {
 	dnsList: ServerStore[]
 	settings: SettingInStore
 	defaultServer: ServerStore | null
+	activeEncryptedConnection: ActiveEncryptedConnection | null
 }

--- a/src/shared/validators/__test__/dns-encrypted.validator.spec.ts
+++ b/src/shared/validators/__test__/dns-encrypted.validator.spec.ts
@@ -1,0 +1,94 @@
+import {
+	isValidDnsAddress,
+	isValidDohUrl,
+	isValidDotHost,
+	validateServerAddresses,
+} from '../dns.validator'
+
+describe('dns.validator', () => {
+	describe('isValidDnsAddress', () => {
+		it('accepts IPv4', () => {
+			expect(isValidDnsAddress('1.1.1.1')).toBe(true)
+		})
+
+		it('rejects non-IPv4', () => {
+			expect(isValidDnsAddress('cloudflare-dns.com')).toBe(false)
+		})
+	})
+
+	describe('isValidDohUrl', () => {
+		it('accepts https DoH endpoints', () => {
+			expect(isValidDohUrl('https://cloudflare-dns.com/dns-query')).toBe(true)
+			expect(isValidDohUrl('https://dns.example/dns-query?foo=1')).toBe(true)
+		})
+
+		it('rejects non-https', () => {
+			expect(isValidDohUrl('http://example.com/dns-query')).toBe(false)
+			expect(isValidDohUrl('cloudflare-dns.com')).toBe(false)
+		})
+	})
+
+	describe('isValidDotHost', () => {
+		it('accepts host and host:port', () => {
+			expect(isValidDotHost('cloudflare-dns.com')).toBe(true)
+			expect(isValidDotHost('dns.example.com:853')).toBe(true)
+			expect(isValidDotHost('1.1.1.1')).toBe(true)
+		})
+
+		it('rejects urls and bad ports', () => {
+			expect(isValidDotHost('tls://cloudflare-dns.com')).toBe(false)
+			expect(isValidDotHost('dns.example.com:99999')).toBe(false)
+		})
+	})
+
+	describe('validateServerAddresses', () => {
+		it('validates plain dns pairs', () => {
+			expect(
+				validateServerAddresses({
+					protocol: 'plain',
+					servers: ['1.1.1.1', '1.0.0.1'],
+				}),
+			).toBeNull()
+			expect(
+				validateServerAddresses({
+					protocol: 'plain',
+					servers: ['1.1.1.1', '1.1.1.1'],
+				}),
+			).toContain('duplicates')
+		})
+
+		it('validates doh servers', () => {
+			expect(
+				validateServerAddresses({
+					protocol: 'doh',
+					dohUrl: 'https://dns.google/dns-query',
+					servers: [],
+				}),
+			).toBeNull()
+			expect(
+				validateServerAddresses({
+					protocol: 'doh',
+					dohUrl: 'not-a-url',
+					servers: [],
+				}),
+			).toContain('DoH URL')
+		})
+
+		it('validates dot servers', () => {
+			expect(
+				validateServerAddresses({
+					protocol: 'dot',
+					dotHost: 'dns.quad9.net',
+					servers: ['9.9.9.9'],
+				}),
+			).toBeNull()
+			expect(
+				validateServerAddresses({
+					protocol: 'dot',
+					dotHost: '',
+					servers: ['9.9.9.9'],
+				}),
+			).toContain('DoT hostname')
+		})
+	})
+})

--- a/src/shared/validators/dns.validator.ts
+++ b/src/shared/validators/dns.validator.ts
@@ -1,4 +1,81 @@
-import { isIPv4 } from 'net'
+import { isIPv4 } from 'node:net'
+import type { DnsProtocol, Server } from '../interfaces/server.interface'
+import { getServerProtocol } from '../interfaces/server.interface'
+
 export function isValidDnsAddress(value: string) {
 	return isIPv4(value)
+}
+
+export function isValidDohUrl(value: string): boolean {
+	if (!value || typeof value !== 'string') return false
+	try {
+		const url = new URL(value.trim())
+		return url.protocol === 'https:' && Boolean(url.hostname)
+	} catch {
+		return false
+	}
+}
+
+/** Hostname or host:port for DNS-over-TLS (default port 853). */
+export function isValidDotHost(value: string): boolean {
+	if (!value || typeof value !== 'string') return false
+	const trimmed = value.trim()
+	if (trimmed.includes('://') || /\s/.test(trimmed)) return false
+
+	const [host, portPart] = trimmed.split(':')
+	if (!host || host.length > 253) return false
+	if (portPart !== undefined) {
+		const port = Number(portPart)
+		if (!Number.isInteger(port) || port < 1 || port > 65535) return false
+	}
+
+	// Allow IPv4 or domain labels
+	if (isIPv4(host)) return true
+	return /^(?=.{1,253}$)(?!-)[a-zA-Z0-9-]{1,63}(?<!-)(\.(?!-)[a-zA-Z0-9-]{1,63}(?<!-))*$/.test(
+		host
+	)
+}
+
+export function validateServerAddresses(server: Partial<Server>): string | null {
+	const protocol: DnsProtocol = getServerProtocol(server as Server)
+
+	if (protocol === 'doh') {
+		if (!server.dohUrl || !isValidDohUrl(server.dohUrl)) {
+			return 'A valid DoH URL (https://...) is required'
+		}
+		if (server.servers?.[0] && !isValidDnsAddress(server.servers[0])) {
+			return 'Bootstrap DNS IP is not valid'
+		}
+		if (server.servers?.[1] && !isValidDnsAddress(server.servers[1])) {
+			return 'Alternate bootstrap DNS IP is not valid'
+		}
+		return null
+	}
+
+	if (protocol === 'dot') {
+		if (!server.dotHost || !isValidDotHost(server.dotHost)) {
+			return 'A valid DoT hostname is required'
+		}
+		if (server.servers?.[0] && !isValidDnsAddress(server.servers[0])) {
+			return 'Bootstrap DNS IP is not valid'
+		}
+		if (server.servers?.[1] && !isValidDnsAddress(server.servers[1])) {
+			return 'Alternate bootstrap DNS IP is not valid'
+		}
+		return null
+	}
+
+	if (!server.servers?.[0] || !isValidDnsAddress(server.servers[0])) {
+		return 'DNS1 is required'
+	}
+	if (server.servers?.[1] && !isValidDnsAddress(server.servers[1])) {
+		return 'DNS2 is not valid'
+	}
+	if (
+		server.servers?.[1] &&
+		server.servers[0].toString() === server.servers[1].toString()
+	) {
+		return 'DNS 1 and DNS 2 values must not be duplicates.'
+	}
+	return null
 }


### PR DESCRIPTION
## Summary
- Add DoH (DNS-over-HTTPS) and DoT (DNS-over-TLS) support for custom endpoints (including AdGuard Home), closing #62.
- Prefer OS-native paths when available (Windows DoH via `netsh dns add encryption`, Linux DoT via NetworkManager / resolvectl), with a local `127.0.0.1:53` stub proxy fallback that forwards queries to the encrypted upstream.
- Extend the server model, validators, Add Server UI (DoH/DoT tabs), home server card, and seed list with Cloudflare/Quad9 encrypted presets.

## Test plan
- [ ] Add a custom DoH server (e.g. `https://dns.google/dns-query`) and connect; confirm DNS resolution works, then disconnect
- [ ] Add a custom DoT server (hostname + optional bootstrap IP) and connect/disconnect
- [ ] On Windows 11: connect Cloudflare DoH and verify encryption is registered (`netsh dns show encryption`)
- [ ] On Linux with NetworkManager: connect Cloudflare DoT and verify `dns-over-tls` / resolvectl settings
- [ ] Confirm plain IPv4 servers still connect exactly as before
- [ ] Confirm active encrypted connection is restored in the UI after app reload while still connected