### PR TITLE
feat: language switcher, merged translations, and analytics toggle

### DIFF
--- a/src/i18n/ar/index.ts
+++ b/src/i18n/ar/index.ts
@@ -1,0 +1,58 @@
+import type { Translation } from '../i18n-types'
+
+const ar: Translation = {
+	pages: {
+		home: {
+			homeTitle: 'مغير DNS',
+			connectedHTML: 'متصل بـ <u>{currentActive}</u>',
+			connected: 'متصل بـ {currentActive}',
+			disconnected: 'غير متصل',
+			unknownServer: 'متصل بخادم غير معروف.',
+		},
+		settings: {
+			title: 'الإعدادات',
+			autoRunningTitle: 'التشغيل التلقائي للبرنامج عند تشغيل النظام',
+			langChanger: 'تغيير اللغة',
+			themeChanger: 'المظهر',
+		},
+		addCustomDns: {
+			NameOfServer: 'اسم الخادم',
+			serverAddr: 'عنوان الخادم',
+		},
+	},
+	themeChanger: {
+		dark: 'داكن',
+		light: 'فاتح',
+	},
+	buttons: {
+		update: 'تحديث القائمة',
+		favDnsServer: 'إضافة خادم (DNS) مخصص',
+		add: 'إضافة',
+		flushDns: 'إفراغ',
+		ping: 'بينغ',
+	},
+	waiting: 'يرجى الانتظار...',
+	disconnecting: 'جاري قطع الاتصال...',
+	connecting: 'جاري الاتصال...',
+	successful: 'ناجح',
+	help_connect: 'انقر للاتصال',
+	help_disconnect: 'انقر لقطع الاتصال',
+	dialogs: {
+		fetching_data_from_repo: 'جاري جلب البيانات من المستودع...',
+		removed_server: '{serverName} تمت إزالته بنجاح من القائمة.',
+		added_server: 'الخادم {serverName} تمت إضافته بنجاح.',
+		flush_successful: 'تم الإفراغ بنجاح.',
+		flush_failure: 'فشل الإفراغ.',
+	},
+	errors: {
+		error_fetching_data: 'خطأ في استلام البيانات من {target}',
+	},
+	validator: {
+		invalid_dns1: 'قيمة DNS 1 غير صالحة.',
+		invalid_dns2: 'قيمة DNS 2 غير صالحة.',
+		dns1_dns2_duplicates: 'يجب ألا تكون قيم DNS 1 و DNS 2 مكررة.',
+	},
+	version: 'الإصدار',
+}
+
+export default ar

--- a/src/i18n/i18n-types.ts
+++ b/src/i18n/i18n-types.ts
@@ -9,7 +9,15 @@ import type {
 export type BaseTranslation = BaseTranslationType
 export type BaseLocale = 'fa'
 
-export type Locales = 'eng' | 'fa' | 'ru'
+export type Locales =
+	| 'ar'
+	| 'eng'
+	| 'fa'
+	| 'it'
+	| 'ja'
+	| 'ko'
+	| 'ru'
+	| 'zh'
 
 export type Translation = RootTranslation
 

--- a/src/i18n/i18n-util.async.ts
+++ b/src/i18n/i18n-util.async.ts
@@ -6,9 +6,14 @@ import type { Locales, Translations } from './i18n-types'
 import { loadedFormatters, loadedLocales, locales } from './i18n-util'
 
 const localeTranslationLoaders = {
+	ar: () => import('./ar'),
 	eng: () => import('./eng'),
 	fa: () => import('./fa'),
+	it: () => import('./it'),
+	ja: () => import('./ja'),
+	ko: () => import('./ko'),
 	ru: () => import('./ru'),
+	zh: () => import('./zh'),
 }
 
 const updateDictionary = (

--- a/src/i18n/i18n-util.sync.ts
+++ b/src/i18n/i18n-util.sync.ts
@@ -5,14 +5,24 @@ import { initFormatters } from './formatters'
 import type { Locales, Translations } from './i18n-types'
 import { loadedFormatters, loadedLocales, locales } from './i18n-util'
 
+import ar from './ar'
 import eng from './eng'
 import fa from './fa'
+import it from './it'
+import ja from './ja'
+import ko from './ko'
 import ru from './ru'
+import zh from './zh'
 
 const localeTranslations = {
+	ar,
 	eng,
 	fa,
+	it,
+	ja,
+	ko,
 	ru,
+	zh,
 }
 
 export const loadLocale = (locale: Locales): void => {

--- a/src/i18n/i18n-util.ts
+++ b/src/i18n/i18n-util.ts
@@ -22,7 +22,16 @@ import type {
 
 export const baseLocale: Locales = 'fa'
 
-export const locales: Locales[] = ['eng', 'fa', 'ru']
+export const locales: Locales[] = [
+	'ar',
+	'eng',
+	'fa',
+	'it',
+	'ja',
+	'ko',
+	'ru',
+	'zh',
+]
 
 export const isLocale = (locale: string): locale is Locales =>
 	locales.includes(locale as Locales)

--- a/src/i18n/it/index.ts
+++ b/src/i18n/it/index.ts
@@ -1,0 +1,59 @@
+import type { Translation } from '../i18n-types'
+
+const it: Translation = {
+	pages: {
+		home: {
+			homeTitle: 'DNS Changer',
+			connectedHTML: 'Connesso a <u>{currentActive}</u>',
+			connected: 'Connesso a {currentActive}',
+			disconnected: 'Disconnesso',
+			unknownServer: 'connesso a un server sconosciuto.',
+		},
+		settings: {
+			title: 'Impostazioni',
+			autoRunningTitle:
+				"Esecuzione automatica del programma all'avvio del sistema",
+			langChanger: 'Cambia lingua',
+			themeChanger: 'Tema',
+		},
+		addCustomDns: {
+			NameOfServer: 'Nome server',
+			serverAddr: 'Indirizzo server',
+		},
+	},
+	themeChanger: {
+		dark: 'Scuro',
+		light: 'Chiaro',
+	},
+	buttons: {
+		update: "Aggiorna l'elenco",
+		favDnsServer: 'Aggiunta di un server (DNS) personalizzato',
+		add: 'Aggiungi',
+		flushDns: 'Reset DNS',
+		ping: 'Ping',
+	},
+	waiting: 'Attendere prego...',
+	disconnecting: 'disconnessione...',
+	connecting: 'connessione...',
+	successful: 'riuscita',
+	help_connect: 'Clicca per connetterti',
+	help_disconnect: 'Clicca per disconnetterti',
+	dialogs: {
+		fetching_data_from_repo: 'recupero dati dal repository...',
+		removed_server: "{serverName} è stato rimosso con successo dall'elenco.",
+		added_server: 'Il server {serverName} è stato aggiunto con successo.',
+		flush_successful: 'Pulizia completata con successo.',
+		flush_failure: 'Pulizia fallita.',
+	},
+	errors: {
+		error_fetching_data: 'Errore nella ricezione dei dati dal {target}',
+	},
+	validator: {
+		invalid_dns1: 'Il valore DNS 1 non è valido.',
+		invalid_dns2: 'Il valore DNS 2 non è valido.',
+		dns1_dns2_duplicates: 'I valori DNS 1 e DNS 2 non devono essere duplicati.',
+	},
+	version: 'versione',
+}
+
+export default it

--- a/src/i18n/ja/index.ts
+++ b/src/i18n/ja/index.ts
@@ -1,0 +1,58 @@
+import type { Translation } from '../i18n-types'
+
+const ja: Translation = {
+	pages: {
+		home: {
+			homeTitle: 'DNS Changer',
+			connectedHTML: '<u>{currentActive}</u> に接続済み',
+			connected: '{currentActive} に接続済み',
+			disconnected: '切断',
+			unknownServer: '不明なサーバーに接続済み。',
+		},
+		settings: {
+			title: '設定',
+			autoRunningTitle: 'システム起動時にプログラムを自動的に実行',
+			langChanger: '言語の変更',
+			themeChanger: 'テーマ',
+		},
+		addCustomDns: {
+			NameOfServer: 'サーバー名',
+			serverAddr: 'サーバー アドレス',
+		},
+	},
+	themeChanger: {
+		dark: 'ダーク',
+		light: 'ライト',
+	},
+	buttons: {
+		update: 'リストを更新',
+		favDnsServer: 'カスタム(DNS)サーバーの追加',
+		add: '追加',
+		flushDns: '消去(Flush)',
+		ping: 'Ping',
+	},
+	waiting: 'お待ちください...',
+	disconnecting: '切断中...',
+	connecting: '接続中...',
+	successful: '成功',
+	help_connect: 'クリックして接続',
+	help_disconnect: 'クリックして切断',
+	dialogs: {
+		fetching_data_from_repo: 'リポジトリからデータを取得中......',
+		removed_server: '{serverName} はリストから正常に削除されました。',
+		added_server: 'サーバー {serverName} が正常に追加されました。',
+		flush_successful: '消去(Flush)は成功しました。',
+		flush_failure: '消去(Flush)に失敗しました。',
+	},
+	errors: {
+		error_fetching_data: '{target} からのデータ受信エラー',
+	},
+	validator: {
+		invalid_dns1: 'DNS 値 1 は無効です。',
+		invalid_dns2: 'DNS 値 2 は無効です。',
+		dns1_dns2_duplicates: 'DNS 1 と DNS 2 の値は重複できません。',
+	},
+	version: 'バージョン',
+}
+
+export default ja

--- a/src/i18n/ko/index.ts
+++ b/src/i18n/ko/index.ts
@@ -1,0 +1,58 @@
+import type { Translation } from '../i18n-types'
+
+const ko: Translation = {
+	pages: {
+		home: {
+			homeTitle: 'DNS Changer',
+			connectedHTML: '<u>{currentActive}</u>에 연결됨',
+			connected: '{currentActive}에 연결됨',
+			disconnected: '연결이 끊어졌습니다',
+			unknownServer: '알 수 없는 서버에 연결되었습니다.',
+		},
+		settings: {
+			title: '설정',
+			autoRunningTitle: '시스템이 켜지면 프로그램이 자동으로 실행됩니다',
+			langChanger: '언어 변환',
+			themeChanger: '테마',
+		},
+		addCustomDns: {
+			NameOfServer: '서버 이름',
+			serverAddr: '서버 주소',
+		},
+	},
+	themeChanger: {
+		dark: '어두운',
+		light: '밝은',
+	},
+	buttons: {
+		update: '목록 업데이트',
+		favDnsServer: '사용자 지정 (DNS) 서버 추가',
+		add: '추가',
+		flushDns: '비우기',
+		ping: '핑',
+	},
+	waiting: '기다려 주세요...',
+	disconnecting: '연결을 끊는 중...',
+	connecting: '연결을 하는 중...',
+	successful: '성공',
+	help_connect: '연결하려면 클릭하세요',
+	help_disconnect: '연결 해제하려면 클릭하세요',
+	dialogs: {
+		fetching_data_from_repo: '저장소에서 데이터를 가져오는 중...',
+		removed_server: '{serverName}이(가) 목록에서 성공적으로 제거되었습니다.',
+		added_server: 'Server {serverName}이(가) 성공적으로 추가되었습니다.',
+		flush_successful: '비우기가 성공했습니다.',
+		flush_failure: '비우기가 실패했습니다.',
+	},
+	errors: {
+		error_fetching_data: '{target}에서 데이터를 수신하는 중 오류 발생',
+	},
+	validator: {
+		invalid_dns1: 'DNS 값 1은 유효하지 않습니다.',
+		invalid_dns2: 'DNS 값 2은 유효하지 않습니다.',
+		dns1_dns2_duplicates: 'DNS 1과 DNS 2 값은 중복되지 않아야 합니다.',
+	},
+	version: '버전',
+}
+
+export default ko

--- a/src/i18n/zh/index.ts
+++ b/src/i18n/zh/index.ts
@@ -1,0 +1,58 @@
+import type { Translation } from '../i18n-types'
+
+const zh: Translation = {
+	pages: {
+		home: {
+			homeTitle: 'DNS Changer',
+			connectedHTML: '已连接到 <u>{currentActive}</u>',
+			connected: '已连接到 {currentActive}',
+			disconnected: '已断开连接',
+			unknownServer: '已连接到未知服务器。',
+		},
+		settings: {
+			title: '设置',
+			autoRunningTitle: '系统开机时自动执行程序',
+			langChanger: '语言更改',
+			themeChanger: '主题',
+		},
+		addCustomDns: {
+			NameOfServer: '服务器名称',
+			serverAddr: '服务器地址',
+		},
+	},
+	themeChanger: {
+		dark: '深色',
+		light: '浅色',
+	},
+	buttons: {
+		update: '更新列表',
+		favDnsServer: '添加自定义 (DNS) 服务器',
+		add: '添加',
+		flushDns: '清空',
+		ping: 'Ping',
+	},
+	waiting: '请稍候...',
+	disconnecting: '正在断开连接...',
+	connecting: '正在连接…',
+	successful: '成功',
+	help_connect: '点击连接',
+	help_disconnect: '单击断开连接',
+	dialogs: {
+		fetching_data_from_repo: '正在从存储库中获取数据...',
+		removed_server: '{serverName} 已成功从列表中删除。',
+		added_server: '服务器 {serverName} 已成功添加。',
+		flush_successful: '清空操作成功。',
+		flush_failure: '清空失败。',
+	},
+	errors: {
+		error_fetching_data: '从 {target} 接收数据时出错',
+	},
+	validator: {
+		invalid_dns1: 'DNS 值 1 无效。',
+		invalid_dns2: 'DNS 值 2 无效。',
+		dns1_dns2_duplicates: 'DNS 1 和 DNS 2 值不能重复。',
+	},
+	version: '版本',
+}
+
+export default zh

--- a/src/renderer/Wrappers/pages.wrapper.tsx
+++ b/src/renderer/Wrappers/pages.wrapper.tsx
@@ -1,6 +1,7 @@
 import React, { type JSX, useState } from 'react'
 
 import { useI18nContext } from '../../i18n/i18n-react'
+import { isRtlLocale } from '../../shared/constants/languages.constant'
 
 interface Props {
 	children: JSX.Element
@@ -10,7 +11,10 @@ export function PageWrapper(prop: Props) {
 	const [currentPage] = useState('/')
 	const { locale } = useI18nContext()
 	return (
-		<div className="h-full bg-base-300" dir={locale === 'fa' ? 'rtl' : 'ltr'}>
+		<div
+			className="h-full bg-base-300"
+			dir={isRtlLocale(locale) ? 'rtl' : 'ltr'}
+		>
 			{React.cloneElement(prop.children, { currentPage })}
 		</div>
 	)

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -1,24 +1,30 @@
 import React, { useState, useEffect, type JSX } from 'react'
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { AnimatePresence, motion } from 'framer-motion'
 import { Toaster } from 'react-hot-toast'
 import type { IconType } from 'react-icons'
 import { BsPower } from 'react-icons/bs'
 import { MdOutlineExplore } from 'react-icons/md'
 import { TbSettings, TbSmartHome } from 'react-icons/tb'
 import TypesafeI18n from '../i18n/i18n-react'
+import type { Locales } from '../i18n/i18n-types'
 import { loadLocaleAsync } from '../i18n/i18n-util.async'
-import type { SettingInStore, Settings } from '../shared/interfaces/settings.interface'
+import { isRtlLocale } from '../shared/constants/languages.constant'
+import type {
+	SettingInStore,
+	Settings,
+} from '../shared/interfaces/settings.interface'
 import { PageWrapper } from './Wrappers/pages.wrapper'
+import { NavbarComponent } from './component/head/navbar.component'
 import { ExplorePage } from './pages/explore.page'
 import { HomePage } from './pages/home.page'
 import { SettingPage } from './pages/setting.page'
 import { ShutdownPage } from './pages/shutdown.page'
+import { initAnalytics } from './utils/analytics.util'
 import { getThemeSystem, themeChanger } from './utils/theme.util'
+
 export let settingStore: SettingInStore = window.storePreload.get('settings')
-import ReactGA from 'react-ga4'
-import { NavbarComponent } from './component/head/navbar.component'
-import { AnimatePresence, motion } from 'framer-motion'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 interface Page {
 	key: string
@@ -39,8 +45,12 @@ const pages: Page[] = [
 	{ key: '/setting', element: <SettingPage />, icon: TbSettings, name: 'Setting' },
 ]
 const queryClient = new QueryClient()
+
 export function App() {
 	const [wasLoaded, setWasLoaded] = useState(false)
+	const [locale, setLocale] = useState<Locales>(
+		(settingStore?.lng as Locales) || 'eng',
+	)
 
 	const [currentPage, setCurrentPage] = useState<Page>(pages[0])
 	const [currentPath, setCurrentPath] = useState<string>('/')
@@ -53,13 +63,17 @@ export function App() {
 	}, [currentPath])
 
 	useEffect(() => {
-		ReactGA.initialize('G-XJBQXCR24P')
 		async function getSetting() {
 			settingStore = (await window.ipc.getSettings()) as Settings
+			initAnalytics(settingStore)
 		}
 
 		getSetting().then(() => {
-			loadLocaleAsync(settingStore.lng).then(() => setWasLoaded(true))
+			const nextLocale = (settingStore.lng as Locales) || 'eng'
+			loadLocaleAsync(nextLocale).then(() => {
+				setLocale(nextLocale)
+				setWasLoaded(true)
+			})
 		})
 
 		let theme = localStorage.getItem('theme') || 'dark'
@@ -78,10 +92,24 @@ export function App() {
 			})
 
 		themeChanger(theme as any)
+
+		async function onLocaleChange(event: Event) {
+			const next = (event as CustomEvent<Locales>).detail
+			if (!next) return
+			await loadLocaleAsync(next)
+			settingStore.lng = next
+			setLocale(next)
+		}
+
+		window.addEventListener('locale-change', onLocaleChange as EventListener)
 		return () => {
 			window
 				.matchMedia('(prefers-color-scheme: dark)')
 				.removeEventListener('change', () => {})
+			window.removeEventListener(
+				'locale-change',
+				onLocaleChange as EventListener,
+			)
 		}
 	}, [])
 
@@ -90,16 +118,18 @@ export function App() {
 		return currentPath === target
 	}
 
+	const dir = isRtlLocale(locale) ? 'rtl' : 'ltr'
+
 	return (
 		<div className="h-96">
-			<TypesafeI18n locale={settingStore.lng}>
+			<TypesafeI18n locale={locale}>
 				<NavbarComponent />
 				<QueryClientProvider client={queryClient}>
 					<PageWrapper>{currentPage.element}</PageWrapper>
 				</QueryClientProvider>
 				<div
 					className="fixed bottom-0 left-0 right-0 flex items-center justify-around h-16 px-4 bg-base-100"
-					dir={settingStore.lng === 'fa' ? 'rtl' : 'ltr'}
+					dir={dir}
 				>
 					{pages.map((page) => {
 						return (

--- a/src/renderer/component/buttons/connect-btn.component.tsx
+++ b/src/renderer/component/buttons/connect-btn.component.tsx
@@ -1,11 +1,11 @@
 import { useContext, useMemo, useState } from 'react'
-import ReactGA from 'react-ga4'
 import { AiOutlineLoading } from 'react-icons/ai'
 import { CiPower } from 'react-icons/ci'
 
-import { cn } from '../../utils/cn'
 import { serversContext } from '../../context/servers.context'
 import { appNotif } from '../../notifications/appNotif'
+import { trackEvent } from '../../utils/analytics.util'
+import { cn } from '../../utils/cn'
 
 export function ConnectButtonComponent() {
 	const servers = useContext(serversContext)
@@ -59,7 +59,7 @@ export function ConnectButtonComponent() {
 				servers.setCurrentActive(servers.selected)
 				window.ipc.notif(response.message)
 
-				ReactGA.event({
+				trackEvent({
 					category: 'User',
 					action: 'CONNECTED',
 					label: servers.selected.name,

--- a/src/renderer/pages/setting.page.tsx
+++ b/src/renderer/pages/setting.page.tsx
@@ -1,21 +1,26 @@
 import React, { useEffect, useState } from 'react'
-import { useI18nContext } from '../../i18n/i18n-react'
-import { getThemeSystem, themeChanger } from '../utils/theme.util'
 import { CgDarkMode } from 'react-icons/cg'
+import { FaChartBar, FaFileAlt, FaLaptop } from 'react-icons/fa'
 import { HiMoon, HiSun } from 'react-icons/hi'
-import type { SettingInStore } from '../../shared/interfaces/settings.interface'
-import { MdBrowserUpdated } from 'react-icons/md'
-import { VscRunAbove } from 'react-icons/vsc'
+import { MdBrowserUpdated, MdLanguage } from 'react-icons/md'
 import { TbWindowMinimize } from 'react-icons/tb'
-import { FaFileAlt, FaLaptop } from 'react-icons/fa'
-import { ToggleSwitch } from '../component/toggle/toggle-switch.component'
+import { VscRunAbove } from 'react-icons/vsc'
+import { useI18nContext } from '../../i18n/i18n-react'
+import type { Locales } from '../../i18n/i18n-types'
+import { languages } from '../../shared/constants/languages.constant'
+import { isRtlLocale } from '../../shared/constants/languages.constant'
+import type { SettingInStore } from '../../shared/interfaces/settings.interface'
+import { settingStore } from '../app'
 import { ItemSelector } from '../component/item-selector/item-selector'
+import { ToggleSwitch } from '../component/toggle/toggle-switch.component'
+import { syncAnalyticsPreference } from '../utils/analytics.util'
+import { getThemeSystem, themeChanger } from '../utils/theme.util'
 
 export function SettingPage() {
 	const [_, setStartUp] = useState<boolean>(false)
 	const { LL, locale } = useI18nContext()
 	const [settingState, setSettingState] = useState<SettingInStore>(
-		window.storePreload.get('settings')
+		window.storePreload.get('settings'),
 	)
 
 	function toggleStartUp() {
@@ -36,12 +41,28 @@ export function SettingPage() {
 		}))
 	}
 
+	function toggleAnalytics() {
+		setSettingState((prevState) => {
+			const next = !prevState.use_analytic
+			syncAnalyticsPreference(next)
+			return {
+				...prevState,
+				use_analytic: next,
+			}
+		})
+	}
+
 	useEffect(() => {
+		settingStore.lng = settingState.lng
+		settingStore.use_analytic = settingState.use_analytic
 		window.ipc.saveSettings(settingState).catch()
 	}, [settingState])
 
 	return (
-		<div className="p-2 overflow-y-auto" dir={locale === 'fa' ? 'rtl' : 'ltr'}>
+		<div
+			className="p-2 overflow-y-auto"
+			dir={isRtlLocale(locale) ? 'rtl' : 'ltr'}
+		>
 			<div className="max-w-2xl mx-auto">
 				<div className="border shadow-lg bg-base-100 rounded-xl border-base-300">
 					<div className="p-4 space-y-4">
@@ -49,8 +70,20 @@ export function SettingPage() {
 
 						<div className="border-t border-base-300" />
 
+						<LanguageChanger
+							value={settingState.lng}
+							onChange={(lng) => {
+								setSettingState((prev) => ({ ...prev, lng }))
+								window.dispatchEvent(
+									new CustomEvent('locale-change', { detail: lng }),
+								)
+							}}
+							label={LL.pages.settings.langChanger()}
+						/>
+
+						<div className="border-t border-base-300" />
+
 						<div className="space-y-3">
-							{/* Start Up */}
 							<SettingsSwitch
 								id="startUp"
 								checked={settingState.startUp}
@@ -60,7 +93,6 @@ export function SettingPage() {
 								description={LL.pages.settings.autoRunningTitle()}
 							/>
 
-							{/* Auto Update */}
 							<SettingsSwitch
 								id="autoUP"
 								checked={settingState.autoUpdate}
@@ -70,7 +102,6 @@ export function SettingPage() {
 								description="Get updates automatically"
 							/>
 
-							{/* Minimize to Tray */}
 							<SettingsSwitch
 								id="Minimize"
 								checked={settingState.minimize_tray}
@@ -78,6 +109,15 @@ export function SettingPage() {
 								icon={<TbWindowMinimize className="text-secondary" />}
 								title="Minimize to Tray"
 								description="The app moves to tray in background"
+							/>
+
+							<SettingsSwitch
+								id="analytics"
+								checked={settingState.use_analytic}
+								onChange={toggleAnalytics}
+								icon={<FaChartBar className="text-info" />}
+								title="Analytics"
+								description="Share anonymous usage counts (users & servers only)"
 							/>
 						</div>
 
@@ -125,6 +165,10 @@ function SettingsSwitch({
 }: SettingsSwitchProps) {
 	const [isChecked, setIsChecked] = useState(checked)
 
+	useEffect(() => {
+		setIsChecked(checked)
+	}, [checked])
+
 	const handleToggle = () => {
 		setIsChecked(!isChecked)
 		onChange()
@@ -152,7 +196,7 @@ function SettingsSwitch({
 
 function ThemeChanger() {
 	const [currentTheme, setCurrentTheme] = useState(
-		localStorage.getItem('theme') || getThemeSystem()
+		localStorage.getItem('theme') || getThemeSystem(),
 	)
 	const { LL } = useI18nContext()
 
@@ -179,6 +223,35 @@ function ThemeChanger() {
 						label={f.label}
 						onClick={() => setCurrentTheme(f.value)}
 						key={f.value}
+					/>
+				))}
+			</div>
+		</div>
+	)
+}
+
+function LanguageChanger({
+	value,
+	onChange,
+	label,
+}: {
+	value: Locales
+	onChange: (lng: Locales) => void
+	label: string
+}) {
+	return (
+		<div className="space-y-2">
+			<div className="flex items-center gap-2">
+				<MdLanguage className="text-primary" size={16} />
+				<label className="text-sm font-medium text-base-content">{label}</label>
+			</div>
+			<div className="flex flex-wrap gap-2">
+				{languages.map((lang) => (
+					<ItemSelector
+						key={lang.value}
+						isActive={value === lang.value}
+						label={lang.name}
+						onClick={() => onChange(lang.value as Locales)}
 					/>
 				))}
 			</div>

--- a/src/renderer/utils/analytics.util.ts
+++ b/src/renderer/utils/analytics.util.ts
@@ -1,0 +1,47 @@
+import ReactGA from 'react-ga4'
+import type { SettingInStore } from '../../shared/interfaces/settings.interface'
+
+const GA_MEASUREMENT_ID = 'G-XJBQXCR24P'
+
+let initialized = false
+
+function readSettings(): SettingInStore | null {
+	try {
+		return window.storePreload.get('settings') as SettingInStore
+	} catch {
+		return null
+	}
+}
+
+function analyticsEnabled(settings?: SettingInStore | null): boolean {
+	const store = settings ?? readSettings()
+	return Boolean(store?.use_analytic)
+}
+
+export function initAnalytics(settings?: SettingInStore): void {
+	if (!analyticsEnabled(settings)) {
+		initialized = false
+		return
+	}
+	if (initialized) return
+	ReactGA.initialize(GA_MEASUREMENT_ID)
+	initialized = true
+}
+
+export function trackEvent(params: {
+	category: string
+	action: string
+	label?: string
+	value?: number
+}): void {
+	if (!analyticsEnabled() || !initialized) return
+	ReactGA.event(params)
+}
+
+export function syncAnalyticsPreference(enabled: boolean): void {
+	if (enabled) {
+		initAnalytics({ ...(readSettings() || ({} as SettingInStore)), use_analytic: true })
+	} else {
+		initialized = false
+	}
+}

--- a/src/shared/constants/default-setting.contant.ts
+++ b/src/shared/constants/default-setting.contant.ts
@@ -6,5 +6,5 @@ export const defaultSetting: SettingInStore = {
 	autoUpdate: true,
 	minimize_tray: false,
 	network_interface: 'Auto',
-	use_analytic: true,
+	use_analytic: false,
 }

--- a/src/shared/constants/languages.constant.ts
+++ b/src/shared/constants/languages.constant.ts
@@ -1,22 +1,24 @@
 export interface Language {
 	name: string
 	value: string
-	svg: string
+	rtl?: boolean
 }
+
 export const languages: Array<Language> = [
-	{
-		name: 'فارسی',
-		value: 'fa',
-		svg: '../assets/flags/iran.svg',
-	},
-	{
-		name: 'English',
-		value: 'eng',
-		svg: '../assets/flags/usa.svg',
-	},
-	{
-		name: 'Russian',
-		value: 'ru',
-		svg: '../assets/flags/russia.svg',
-	},
+	{ name: 'فارسی', value: 'fa', rtl: true },
+	{ name: 'English', value: 'eng' },
+	{ name: 'Русский', value: 'ru' },
+	{ name: 'Italiano', value: 'it' },
+	{ name: '日本語', value: 'ja' },
+	{ name: 'العربية', value: 'ar', rtl: true },
+	{ name: '中文', value: 'zh' },
+	{ name: '한국어', value: 'ko' },
 ]
+
+export const RTL_LOCALES = new Set(
+	languages.filter((l) => l.rtl).map((l) => l.value),
+)
+
+export function isRtlLocale(locale: string): boolean {
+	return RTL_LOCALES.has(locale)
+}


### PR DESCRIPTION
## Summary
- Restore the Settings language switcher and wire live locale changes (including RTL for Persian/Arabic).
- Merge community translations: Italian (#127 / #101), Japanese (#125), Arabic (#84), Chinese (#56), Korean (#209 / #135) — with syntax fixes where needed.
- Honor `use_analytic`: Google Analytics initializes and tracks connect events only when enabled; new installs default to opt-in (off).

## Test plan
- [ ] Open Settings → change language across eng/fa/ru/it/ja/ar/zh/ko and confirm UI strings update without restart
- [ ] Confirm fa and ar layout direction is RTL
- [ ] Toggle Analytics on, connect to a DNS server, confirm a GA event can fire; toggle off and confirm no further events
- [ ] Fresh settings store has `use_analytic: false` by default
- [ ] Existing plain settings (startup/update/tray/theme) still work