### PR TITLE
fix: macOS startup crash from duplicate nameservers

### DIFF
--- a/src/main/ipc/dialogs.ts
+++ b/src/main/ipc/dialogs.ts
@@ -268,10 +268,7 @@ async function getCurrentActive(): Promise<{
 				server: {
 					key: 'unknown',
 					servers: dns,
-					names: {
-						eng: 'unknown',
-						fa: 'unknown',
-					},
+					name: 'unknown',
 					avatar: '',
 					isPin: false,
 				},

--- a/src/main/platforms/mac/mac.platform.ts
+++ b/src/main/platforms/mac/mac.platform.ts
@@ -19,7 +19,8 @@ export class MacPlatform extends Platform {
 				"scutil --dns | awk '/nameserver/ { print $3 }'",
 			)
 
-			return stdout.trim().split('\n')
+			// scutil prints the same nameserver once per resolver, so de-duplicate
+			return [...new Set(stdout.trim().split('\n').filter(Boolean))]
 		} catch (e) {
 			throw e
 		}


### PR DESCRIPTION
## Cause

Two bugs compounding:

1. **Wrong shape in the fallback.** When the active DNS does not match any stored server, `getCurrentActive` returns a placeholder built with a legacy `names: { eng, fa }` field. `ServerStore` declares `name: string`, so `ServerInfoCardComponent` crashes on `servers.selected.name.length`.

2. **That branch is always taken on macOS.** `getActiveDns` runs `scutil --dns | awk '/nameserver/ { print $3 }'`, which prints each nameserver once per resolver. The result contains duplicates (e.g. `["1.1.1.1", "1.1.1.1"]`), and the lookup compares `server.servers.toString() === dns.toString()`, so a stored server never matches. Every macOS launch fell into the broken placeholder path.

Windows and Linux were unaffected because their `getActiveDns` implementations return a de-duplicated list.

## Fix

- `src/main/ipc/dialogs.ts` — placeholder now uses `name: 'unknown'`, matching the `ServerStore` interface.
- `src/main/platforms/mac/mac.platform.ts` — de-duplicate and drop empty entries from the `scutil` output, so matching against the stored DNS list works.

## Testing

- Launched on macOS with a stored server active: card renders, server correctly shown as connected.
- Launched with a DNS not in the list: card renders the `unknown` placeholder instead of crashing.

Fixes #220

<img width="1710" height="1224" alt="image" src="https://github.com/user-attachments/assets/e4341b8f-8568-4970-a945-6bce490e1063" />
