### PR TITLE
fix: harden unknown-server path and guard renderer name deref (follow-up to #223)

### DIFF
--- a/src/main/ipc/dialogs.ts
+++ b/src/main/ipc/dialogs.ts
@@ -238,7 +238,7 @@ function getCurrentLng(): Locales {
 
 async function getCurrentActive(): Promise<{
 	success: boolean
-	server?: Partial<ServerStore>
+	server?: ServerStore | null
 	isDefault?: boolean
 	message?: string
 }> {
@@ -248,9 +248,9 @@ async function getCurrentActive(): Promise<{
 		if (!dns.length) return { success: false, server: null }
 
 		const servers = store.get('dnsList') || []
-		const server: ServerStore | null = servers.find(
-			(server) => server.servers.toString() === dns.toString(),
-		)
+		const server: ServerStore | null =
+			servers.find((server) => server.servers.toString() === dns.toString()) ??
+			null
 		const defaultServer = store.get('defaultServer')
 		if (defaultServer) {
 			// if default server is connected, then return it as not connected
@@ -267,9 +267,11 @@ async function getCurrentActive(): Promise<{
 				success: true,
 				server: {
 					key: 'unknown',
+					name: 'Unknown',
 					servers: dns,
-					name: 'unknown',
-					avatar: '',
+					avatar: 'def.png',
+					rate: 0,
+					tags: [],
 					isPin: false,
 				},
 			}

--- a/src/renderer/component/cards/server-info/index.tsx
+++ b/src/renderer/component/cards/server-info/index.tsx
@@ -117,10 +117,9 @@ export function ServerInfoCardComponent({ loadingCurrentActive }: Prop) {
 
 	const isConnected = servers.currentActive?.key === servers.selected.key
 
-	const name =
-		servers.selected.name.length > 18
-			? `${servers.selected.name.slice(0, 18)}...`
-			: servers.selected.name
+	const serverName = servers.selected.name || 'Unknown'
+
+	const name = serverName.length > 18 ? `${serverName.slice(0, 18)}...` : serverName
 
 	const network =
 		servers.network && servers.network.length > 18


### PR DESCRIPTION
Follow-up to #223 / #220.

**Rebased onto `main` after #223 landed.** @SamadiPour independently found the same root cause and fixed the `names` → `name` field while I was investigating, so the crash itself is already resolved on `main`. This PR is now purely additive on top of that fix: it hardens the same code path so the bug can't come back, and adds the renderer-side guard, which #223 didn't cover.

## The failure, for the record

`getCurrentActive()` builds a synthetic "unknown" server when the active system DNS doesn't match any stored server. It used the legacy `names: { eng, fa }` field and had no `name` — a leftover from the refactor that renamed `names` → `name` everywhere else. `ServerInfoCardComponent` then did `servers.selected.name.length`, which threw `TypeError: Cannot read properties of undefined (reading 'length')` during render and unmounted the whole React tree.

This hit **every user whose system DNS isn't one of the stored servers** — i.e. anyone not already connected through the app. That's why it reproduced on clean installs.

| Version | Code in `server-info` | Result |
| --- | --- | --- |
| v2.3.6 | `selected.name?.length` | works — the "last working version" in the thread |
| v2.3.7 | `selected.name.length` (optional chaining dropped in the UI overhaul) | crash → **blank screen** |
| v2.3.8 / v2.3.9 / v2.3.10 | same | **blank screen** |
| v2.3.11-beta | same crash, ErrorBoundary added in #222 | **"Something went wrong"** |

So #222 didn't introduce a new problem — the renderer had been crashing the same way since v2.3.7, and the new ErrorBoundary just made an invisible crash visible. That also explains @s-diaco's report that v2.3.11-beta showed the error screen **with nothing in the logs**: the failure was in the renderer and never reached `userLogger`.

## What this PR adds on top of #223

**`src/main/ipc/dialogs.ts`**
- **Return type `Partial<ServerStore>` → `ServerStore | null`.** This is the part that matters most: `Partial<>` made every required field optional, which is precisely why a server object with no `name` type-checked and shipped. With the real type, omitting a required field is now a compile error. Verified — deleting `name` from the object now fails with `Property 'name' is missing in type … but required in type 'ServerStore'`.
- **Adds the required `rate` / `tags`** so the unknown server actually satisfies `ServerStore` rather than only appearing to.
- **`avatar: 'def.png'` instead of `''`**, so the card stops requesting `./servers-icon/` — a guaranteed 404 on every launch — before its `onError` handler falls back to the default icon.
- `?? null` on the `.find()` so the declared `ServerStore | null` is honest (`.find()` returns `undefined`).

**`src/renderer/component/cards/server-info/index.tsx`**
- Restores the guard v2.3.6 had. #223 fixed the one object that produced a nameless server, but the renderer still hard-dereferences `.name`, so any other malformed entry — including older or corrupted entries already sitting in users' stores — takes down the entire app. Verified this is load-bearing: with a nameless entry in the store, this line still crashes the app on current `main`.

One cosmetic note: I used `name: 'Unknown'` rather than `'unknown'`, matching what v2.3.6 displayed. It's the string users see on the card. Happy to drop that back if you prefer.